### PR TITLE
Add Compact Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ only: ['pipe'] // imports only `pipe`
   + [`repeat`](#repeat)
   + [`range`](#range)
   + [`join`](#join)
+  + [`compact`](#compact)
 * [Object](#object-helpers)
   + [`group-by`](#group-by)
 * [Math](#math-helpers)
@@ -282,6 +283,17 @@ Joins the given array with an optional separator into a string.
 
 ```hbs
 {{join categories ', '}}
+```
+
+**[⬆️ back to top](#available-helpers)**
+
+#### `compact`
+Removes blank items from an array. 
+
+```hbs
+{{#each (compact arrayWithBlanks) as |notBlank|}}
+  {{notBlank}} is most definitely not blank!
+{{/each}}
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/addon/helpers/compact.js
+++ b/addon/helpers/compact.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+const {
+  Helper,
+  get,
+  set,
+  observer,
+  isPresent,
+  isArray,
+  A: emberArray,
+  computed: { filter }
+} = Ember;
+
+export default Helper.extend({
+  array: null,
+
+  compute([array]) {
+    if (!isArray(array)) {
+      return emberArray([array]);
+    }
+
+    set(this, 'array', array);
+
+    return get(this, 'content');
+  },
+
+  content: filter('array', isPresent),
+
+  contentDidChange: observer('content', function() {
+    this.recompute();
+  })
+});

--- a/addon/index.js
+++ b/addon/index.js
@@ -15,3 +15,4 @@ export { default as DecHelper } from './helpers/dec';
 export { default as ToggleHelper } from './helpers/toggle';
 export { default as JoinHelper } from './helpers/join';
 export { default as WHelper } from './helpers/w';
+export { default as CompactHelper } from './helpers/compacy';

--- a/app/helpers/compact.js
+++ b/app/helpers/compact.js
@@ -1,0 +1,1 @@
+export { default, compact } from 'ember-composable-helpers/helpers/compact';

--- a/tests/integration/helpers/compact-test.js
+++ b/tests/integration/helpers/compact-test.js
@@ -1,0 +1,62 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const { A: emberArray, run } = Ember;
+
+moduleForComponent('compact', 'Integration | Helper | {{compact}}', {
+  integration: true
+});
+
+test('Removes empty values in standard arrays', function(assert) {
+  this.set('array', emberArray([1, 2, null, 3, false]));
+  this.render(hbs`
+    {{~#each (compact array) as |value|~}}
+      {{value}}
+    {{~/each~}}
+  `);
+
+  assert.equal(this.$().text().trim(), '123false', 'null is removed');
+});
+
+test('It graceully handles non-array values', function(assert) {
+  this.set('notArray', 1);
+  this.render(hbs`
+    {{~#each (compact notArray) as |value|~}}
+      {{value}}
+    {{~/each~}}
+  `);
+
+  assert.equal(this.$().text().trim(), '1', 'the non array value is rendered');
+});
+
+test('It recomputes the filter if the array changes', function(assert) {
+  this.set('array', emberArray([1, 2, null, 3]));
+  this.render(hbs`
+    {{~#each (compact array) as |value|~}}
+      {{value}}
+    {{~/each~}}
+  `);
+
+  assert.equal(this.$().text().trim(), '123', 'null is removed');
+
+  this.set('array', emberArray([1, null, null, 3]));
+
+  assert.equal(this.$().text().trim(), '13', 'null is removed');
+});
+
+test('It recomputes the filter if an item in the array changes', function(assert) {
+  let array = emberArray([1, 2, null, 3]);
+  this.set('array', array);
+  this.render(hbs`
+    {{~#each (compact array) as |value|~}}
+      {{value}}
+    {{~/each~}}
+  `);
+
+  assert.equal(this.$().text().trim(), '123', 'null is removed');
+
+  run(() => array.replace(2, 1, [5]));
+
+  assert.equal(this.$().text().trim(), '1253', 'null is removed');
+});


### PR DESCRIPTION
For: https://github.com/DockYard/ember-composable-helpers/issues/56

I thought I'd take a stab at this one — but, the requirement to compact objects leaves me a bit flummoxed. Per the [`each-in` helper](https://github.com/emberjs/ember.js/blob/v2.3.0/packages/ember-htmlbars/lib/helpers/each-in.js#L8), it's "unbound, in that new (or removed) properties added to the target object will not be rendered". 

So even though this compact helper would be dynamically adding/removing keys, the `each-in` helper would never update to render the new/removed keys. 

This PR does not attempt to address compacting based on object values yet — can add that if, even given the constraints, y'all would like to have that added. :) 