### PR TITLE
Make `pipe` work with PromiseProxies

### DIFF
--- a/addon/utils/is-promise.js
+++ b/addon/utils/is-promise.js
@@ -1,7 +1,13 @@
 import Ember from 'ember';
 
-const { RSVP: { Promise }, isPresent } = Ember;
+const { typeOf } = Ember;
+
+function isPromiseLike(obj = {}) {
+  return typeOf(obj.then) === 'function' &&
+    typeOf(obj.catch) === 'function' &&
+    typeOf(obj.finally) === 'function';
+}
 
 export default function isPromise(obj) {
-  return isPresent(obj) && obj instanceof Promise;
+  return typeOf(obj) === 'object' && isPromiseLike(obj);
 }

--- a/tests/unit/utils/is-promise-test.js
+++ b/tests/unit/utils/is-promise-test.js
@@ -19,6 +19,10 @@ let testData = [
     expected: true
   },
   {
+    value: { then: K, catch: K, finally: K },
+    expected: true
+  },
+  {
     value: { then: K },
     expected: false
   },
@@ -32,6 +36,10 @@ let testData = [
   },
   {
     value: ['meow'],
+    expected: false
+  },
+  {
+    value: null,
     expected: false
   }
 ];


### PR DESCRIPTION
- Relaxed the `instanceof` check to duck type if the object implements
  Promise-like methods to work with Objects that include the
  PromiseProxy mixin

Closes #102