### PR TITLE
check for value presence rather than value

### DIFF
--- a/addon/helpers/filter-by.js
+++ b/addon/helpers/filter-by.js
@@ -38,7 +38,7 @@ export default Helper.extend({
 
     let filterFn;
 
-    if (value) {
+    if (isPresent(value)) {
       if (typeof value === 'function') {
         filterFn = (item) => value(get(item, byPath));
       } else {

--- a/addon/helpers/reject-by.js
+++ b/addon/helpers/reject-by.js
@@ -7,6 +7,7 @@ const {
   get,
   isArray,
   isEmpty,
+  isPresent,
   observer,
   set
 } = Ember;
@@ -37,7 +38,7 @@ export default Helper.extend({
 
     let filterFn;
 
-    if (value) {
+    if (isPresent(value)) {
       if (typeof value === 'function') {
         filterFn = (item) => !value(get(item, byPath));
       } else {


### PR DESCRIPTION
We were running in to an issue where we were trying to filter-by a property that holds a value of `false`

eg:

```js
{{#each (filter-by "active" false users) as |user|}}
  {{user.name}} is not active.
{{/each}}
```

In this case the helper checks the value which will always return false and then default to the presence check.