### PR TITLE
add invoke helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For action helpers, this will mean better currying semantics:
   + [`reject-by`](#reject-by)
   + [`find-by`](#find-by)
   + [`intersect`](#intersect)
+  + [`invoke`](#invoke)
   + [`union`](#union)
   + [`take`](#take)
   + [`drop`](#drop)
@@ -319,6 +320,20 @@ Creates an array of unique values that are included in all given arrays.
 {{#each (intersect desiredSkills currentSkills) as |skill|}}
   {{skill.name}}
 {{/each}}
+```
+
+**[⬆️ back to top](#available-helpers)**
+
+#### `invoke`
+Invokes a method on an object or on each object of an array.
+
+```hbs
+<div id="popup">
+  {{#each people as |person|}}
+    {{input value=person.name}} <a {{action (invoke "rollbackAttributes")}}>Undo</a>
+  {{/each}}
+  <a {{action (invoke "save" people)}}>Save</a>
+</div>
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/addon/helpers/invoke.js
+++ b/addon/helpers/invoke.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+
+const {
+  RSVP: {all},
+  Helper: { helper },
+  isArray,
+  tryInvoke
+} = Ember;
+
+export function invoke([methodName, ...args]) {
+  let obj = args.pop();
+  if (isArray(obj)) {
+    return function() {
+      return all(
+        obj.map((item) => tryInvoke(item, methodName, args))
+      );
+    };
+  } else {
+    return function() {
+      return tryInvoke(obj, methodName, args);
+    };
+  }
+}
+
+export default helper(invoke);
+

--- a/addon/index.js
+++ b/addon/index.js
@@ -14,6 +14,7 @@ export { default as FindByHelper } from './helpers/find-by';
 export { default as GroupByHelper } from './helpers/group-by';
 export { default as IncHelper } from './helpers/inc';
 export { default as IntersectHelper } from './helpers/intersect';
+export { default as InvokeHelper } from './helpers/invoke';
 export { default as JoinHelper } from './helpers/join';
 export { default as MapByHelper } from './helpers/map-by';
 export { default as PipeHelper } from './helpers/pipe';

--- a/app/helpers/invoke.js
+++ b/app/helpers/invoke.js
@@ -1,0 +1,2 @@
+export { default, invoke } from 'ember-composable-helpers/helpers/invoke';
+

--- a/tests/integration/helpers/invoke-test.js
+++ b/tests/integration/helpers/invoke-test.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+const { RSVP: { resolve } } = Ember;
+
+moduleForComponent('invoke', 'Integration | Helper | {{invoke}}', {
+  integration: true
+});
+
+test('it invokes methods and handles promises', function(assert) {
+  this.set('value', 2);
+  this.set('serverSideComputation', function(x) {
+    return resolve(x * x);
+  });
+  this.on('setValue', (x) => this.set('value', x));
+
+  this.render(hbs`
+    <p>{{value}}</p>
+    <button {{action (pipe (invoke "serverSideComputation" 2 this) (action "setValue"))}}>
+      Calculate
+    </button>
+  `);
+
+  assert.equal(this.$('p').text().trim(), '2', 'precond - should render 2');
+  this.$('button').click();
+  assert.equal(this.$('p').text().trim(), '4', 'should render 4');
+});
+
+test('it invokes methods and handles promise arrays', function(assert) {
+  class Square {
+    constructor(side) {
+      this.side = side;
+    }
+    calcArea() {
+      return resolve(this.side * this.side);
+    }
+  }
+
+  this.set('model', [new Square(1), new Square(2), new Square(3)]);
+  this.on('sumAreas', (x) => {
+    this.set('value', x.reduce((a, b) => a + b));
+  });
+
+  this.render(hbs`
+    <p>{{value}}</p>
+    <button {{action (pipe (invoke "calcArea" this.model) (action "sumAreas"))}}>
+      Calculate
+    </button>
+  `);
+
+  this.$('button').click();
+  assert.equal(this.$('p').text().trim(), '14', 'should render 14');
+});

--- a/tests/unit/helpers/invoke-test.js
+++ b/tests/unit/helpers/invoke-test.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+import { invoke } from 'dummy/helpers/invoke';
+import { module, test } from 'qunit';
+
+const { RSVP: { resolve } } = Ember;
+
+module('Unit | Helper | invoke');
+
+test('it calls method inside objects', function(assert) {
+  let object = {
+    callMom() {
+      return `calling mom in ${[...arguments]}`;
+    }
+  };
+  let action = invoke(['callMom', 1, 2, 3, object]);
+
+  assert.equal(action(), 'calling mom in 1,2,3', 'it calls functions');
+});
+
+test('it is promise aware', function(assert) {
+  let done = assert.async();
+  let object = {
+    func() {
+      return resolve([1, 2, 3]);
+    }
+  };
+
+  let action = invoke(['func', object]);
+  let result = action();
+
+  result.then((resolved) => {
+    assert.deepEqual([1, 2, 3], resolved, 'it is promise aware');
+    done();
+  });
+});
+
+test('it wraps array of promises in another promise', function(assert) {
+  let done = assert.async();
+  let array = Ember.A();
+
+  array.pushObject({
+    func() {
+      return resolve(1);
+    }
+  });
+  array.pushObject({
+    func() {
+      return resolve(2);
+    }
+  });
+  array.pushObject({
+    func() {
+      return resolve(3);
+    }
+  });
+
+  let action = invoke(['func', array]);
+  let result = action();
+
+  result.then((resolved) => {
+    assert.deepEqual([1, 2, 3], resolved, 'it is promise aware');
+    done();
+  });
+});


### PR DESCRIPTION
The main motivation of this helper is to write code like
```handlebars
<a {{action (invoke 'save' model)}}>Save</a>
<a {{action (invoke 'rollbackAttributes' model)}}>Undo</a>
```
against Ember Data models. It avoids boiler plate actions that only call on methods.

As it is intended for use with Ember Data like objects or collections, if the subject of this action is an Array the method gets called on every member of the array. Also, as in the case of 'save()' method above, if the function returns a Promise on the object or on its members (as in the array case) the helper will be aware of that. This way this becomes possible: 

```handlebars
{{#each people as |person|}}
  <p>
    {{input value=person.name}} <a {{action (invoke 'rollbackAttributes' person)}}>Undo</a>
    <span class="model-has-error">{{if person.errors "ERROR"}}</span>
  </p>
{{/each}}
<a {{action (pipe (invoke 'save' people) (action 'hidePopUp'))}}>Save</a>
```
In case 'save()' on any of each model doesn't succeed the pipe chain is halted, the pop-up (which hypothetically holds the form) is not hidden, and the error is shown to the user. If `save()` succeeds the pop-up is hidden.