### PR TITLE
Add queue helper

### DIFF
--- a/addon/helpers/queue.js
+++ b/addon/helpers/queue.js
@@ -1,0 +1,24 @@
+import { helper } from 'ember-helper';
+import isPromise from '../utils/is-promise';
+
+export function queue(actions = []) {
+  return function(...args) {
+    const invokeWithArgs = function(acc, curr) {
+      if (isPromise(acc)) {
+        return acc.then(() => curr(...args));
+      }
+
+      return curr(...args);
+    };
+
+    return actions.reduce((acc, curr, idx) => {
+      if (idx === 0) {
+        return curr(...args);
+      }
+
+      return invokeWithArgs(acc, curr);
+    }, undefined);
+  };
+}
+
+export default helper(queue);

--- a/app/helpers/queue.js
+++ b/app/helpers/queue.js
@@ -1,0 +1,1 @@
+export { default, queue } from 'ember-composable-helpers/helpers/queue';

--- a/tests/integration/helpers/queue-test.js
+++ b/tests/integration/helpers/queue-test.js
@@ -1,0 +1,45 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+const {
+  RSVP: { resolve },
+  run
+} = Ember;
+
+moduleForComponent('queue', 'Integration | Helper | {{queue}}', {
+  integration: true
+});
+
+test('it queues actions', function(assert) {
+  this.on('doAThing', () => null);
+  this.on('process', (x) => this.set('value', x * x));
+  this.on('undoAThing', () => null);
+  this.set('value', 2);
+  this.render(hbs`
+    <p>{{value}}</p>
+    <button {{action (queue (action "doAThing") (action "process") (action "undoAThing")) value}}>
+      Calculate
+    </button>
+  `);
+
+  assert.equal(this.$('p').text().trim(), '2', 'precond - should render 2');
+  this.$('button').click();
+  assert.equal(this.$('p').text().trim(), '4', 'should render 4');
+});
+
+test('it handles promises', function(assert) {
+  this.set('value', 3);
+  this.on('doAThingThatTakesTime', resolve);
+  this.on('process', (x) => this.set('value', x * x));
+  this.render(hbs`
+    <p>{{value}}</p>
+    <button {{action (queue (action "doAThingThatTakesTime") (action "process")) value}}>
+      Calculate
+    </button>
+  `);
+
+  assert.equal(this.$('p').text().trim(), '3', 'precond - should render 3');
+  run(() => this.$('button').click());
+  assert.equal(this.$('p').text().trim(), '9', 'should render 9');
+});

--- a/tests/unit/helpers/queue-test.js
+++ b/tests/unit/helpers/queue-test.js
@@ -1,0 +1,67 @@
+import Ember from 'ember';
+import { queue } from 'dummy/helpers/queue';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+const { RSVP: { resolve, reject }, K } = Ember;
+let sandbox;
+
+const step0 = sinon.spy(() => resolve());
+const step1 = sinon.spy((x) => x);
+const step2 = sinon.spy((x, y) => y);
+const step3 = sinon.spy(() => null);
+const fail  = sinon.spy(() => reject());
+
+module('Unit | Helper | queue', {
+  beforeEach() {
+    sandbox = sinon.sandbox.create();
+  },
+
+  afterEach() {
+    sandbox.restore();
+    step1.reset();
+    step2.reset();
+    step3.reset();
+  }
+});
+
+test('it queues functions', function(assert) {
+  let queued = queue([step1, step2, step3]);
+  queued(2, 4);
+
+  assert.ok(step1.calledOnce, 'step1 called once');
+  assert.ok(step2.calledOnce, 'step2 called once');
+  assert.ok(step3.calledOnce, 'step3 called once');
+});
+
+test('it passes all functions the same arguments', function(assert) {
+  let queued = queue([step1, step2, step3]);
+  queued(2, 4);
+
+  assert.ok(step1.calledWith(2, 4), 'step1 called with correct args');
+  assert.ok(step2.calledWith(2, 4), 'step2 called with correct args');
+  assert.ok(step3.calledWith(2, 4), 'step3 called with correct args');
+});
+
+test('it is promise aware', function(assert) {
+  let done = assert.async();
+  let queued = queue([step0, step1, step2, step3]);
+  let result = queued(2, 4);
+
+  result.then((resolved) => {
+    assert.equal(resolved, null, 'it is promise aware');
+    done();
+  });
+});
+
+test('it aborts the chain if a promise in the queue rejects', function(assert) {
+  let done = assert.async();
+  let queued = queue([step0, fail, step1]);
+
+  queued(2, 4)
+    .catch(K)
+    .finally(() => {
+      assert.equal(step1.callCount, 0, 'should abort the chain');
+      done();
+    });
+});


### PR DESCRIPTION
Similar to the pipe helper, but instead of chaining return values of one action as the arguments of another, this will pass the same arguments to all actions.

Not sure if this is something you're interested in, but I found it useful for a few situations, like chaining a helper function in with the real business function, but without having to make the helper function pass its args along.

Also not sure about the name. Some other possible names: `fork`, `multi`, `do-each`. Open to other suggestions as well.