### PR TITLE
Implementing object-at helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For action helpers, this will mean better currying semantics:
   + [`array`](#array)
   + [`shuffle`](#shuffle)
   + [`flatten`](#flatten)
+  + [`object-at`](#object-at)
 * [Object](#object-helpers)
   + [`group-by`](#group-by)
 * [Math](#math-helpers)
@@ -598,6 +599,15 @@ Flattens an array to a single dimension.
 {{#each (flatten anArrayOfNamesWithMultipleDimensions) as |name|}}
   Name: {{name}}
 {{/each}}
+```
+
+**[⬆️ back to top](#available-helpers)**
+
+#### `object-at`
+Returns the object at the given index of an array.
+
+```hbs
+{{object-at index array}}
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/addon/helpers/object-at.js
+++ b/addon/helpers/object-at.js
@@ -1,0 +1,36 @@
+import Helper from 'ember-helper';
+import { A as emberArray, isEmberArray as isArray } from 'ember-array/utils';
+import computed from 'ember-computed';
+import observer from 'ember-metal/observer';
+import get from 'ember-metal/get';
+import set from 'ember-metal/set';
+
+export function objectAt(index, array) {
+  if (!isArray(array)) {
+    return undefined;
+  }
+
+  index = parseInt(index, 10);
+
+  return emberArray(array).objectAt(index);
+}
+
+export default Helper.extend({
+  content: computed('index', 'array.[]', function() {
+    let index = get(this, 'index');
+    let array = get(this, 'array');
+
+    return objectAt(index, array);
+  }),
+
+  compute([index, array]) {
+    set(this, 'index', index);
+    set(this, 'array', array);
+
+    return get(this, 'content');
+  },
+
+  contentDidChange: observer('content', function() {
+    this.recompute();
+  })
+});

--- a/addon/index.js
+++ b/addon/index.js
@@ -35,3 +35,4 @@ export { default as UnionHelper } from './helpers/union';
 export { default as WHelper } from './helpers/w';
 export { default as WithoutHelper } from './helpers/without';
 export { default as FlattenHelper } from './helpers/flatten';
+export { default as ObjectAtHelper } from './helpers/object-at';

--- a/app/helpers/object-at.js
+++ b/app/helpers/object-at.js
@@ -1,0 +1,1 @@
+export { default, objectAt } from 'ember-composable-helpers/helpers/object-at';

--- a/tests/integration/helpers/object-at-test.js
+++ b/tests/integration/helpers/object-at-test.js
@@ -1,0 +1,49 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+const { A: emberArray, run } = Ember;
+
+moduleForComponent('object-at', 'Integration | Helper | {{object-at}}', {
+  integration: true
+});
+
+test('It gets an object by index', function(assert) {
+  this.set('array', ['apples', 'oranges', 'bananas']);
+  this.set('index', 1);
+
+  this.render(hbs`{{object-at index array}}`);
+
+  assert.equal(this.$().text().trim(), 'oranges', 'the correct object is displayed');
+});
+
+test('It returns undefined with the index is outside the bounds of the array', function(assert) {
+  this.set('array', ['apples', 'oranges', 'bananas']);
+  this.set('index', 5);
+
+  this.render(hbs`{{if (object-at index array) 'true' 'false'}}`);
+
+  assert.equal(this.$().text().trim(), 'false', 'the returned value is falsey');
+});
+
+test('It returns an updated value when the object at the given index changes', function(assert) {
+  this.set('array', emberArray(['apples', 'oranges', 'bananas']));
+  this.set('index', 1);
+
+  this.render(hbs`{{object-at index array}}`);
+
+  assert.equal(this.$().text().trim(), 'oranges', 'the original object is display');
+
+  run(() => this.get('array').removeAt(1, 1));
+
+  assert.equal(this.$().text().trim(), 'bananas', 'the new object is displayed');
+});
+
+test('It returns undefined if using an non-array-like object', function(assert) {
+  this.set('array', 'foo');
+  this.set('index', 1);
+
+  this.render(hbs`{{object-at index array}}`);
+
+  assert.equal(this.$().text().trim(), '', 'nothing is displayed');
+});


### PR DESCRIPTION
The goal of this helper was to facilitate pagination in conjunction with the `chunk` helper. You can get similar results with Ember's `get` helper, but it requires the index to be a string, as far as I can tell.