### PR TITLE
standardize array checks to Ember arrays (#197)

### DIFF
--- a/addon/-private/create-multi-array-helper.js
+++ b/addon/-private/create-multi-array-helper.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import {
   A as emberArray,
-  isEmberArray as isArray
+  isEmberArray
 } from 'ember-array/utils';
 import Helper from 'ember-helper';
 import { guidFor } from 'ember-metal/utils';
@@ -17,7 +17,7 @@ export default function(multiArrayComputed) {
   return Helper.extend({
     compute([...arrays]) {
       set(this, 'arrays', arrays.map((obj) => {
-        if (isArray(obj)) {
+        if (isEmberArray(obj)) {
           return emberArray(obj);
         }
 

--- a/addon/helpers/append.js
+++ b/addon/helpers/append.js
@@ -1,6 +1,6 @@
 import computed from 'ember-computed';
 import get from 'ember-metal/get';
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import createMultiArrayHelper from '../-private/create-multi-array-helper';
 
 export function append(...dependentKeys) {
@@ -12,7 +12,7 @@ export function append(...dependentKeys) {
   return computed(...arrayKeys, function() {
     let array = dependentKeys.map((dependentKey) => {
       let value = get(this, dependentKey);
-      return isArray(value) ? value.toArray() : [value];
+      return isEmberArray(value) ? value.toArray() : [value];
     });
 
     return [].concat(...array);

--- a/addon/helpers/chunk.js
+++ b/addon/helpers/chunk.js
@@ -1,4 +1,4 @@
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import computed from 'ember-computed';
 import Helper from 'ember-helper';
 import get from 'ember-metal/get';
@@ -12,7 +12,7 @@ export function chunk(num, array) {
   let size = max(integer, 0);
 
   let length = 0;
-  if (isArray(array)) {
+  if (isEmberArray(array)) {
     length = get(array, 'length');
   }
 

--- a/addon/helpers/compact.js
+++ b/addon/helpers/compact.js
@@ -1,6 +1,6 @@
 import {
   A as emberArray,
-  isEmberArray as isArray
+  isEmberArray
 } from 'ember-array/utils';
 import { filter } from 'ember-computed';
 import Helper from 'ember-helper';
@@ -11,7 +11,7 @@ import { isPresent } from 'ember-utils';
 
 export default Helper.extend({
   compute([array]) {
-    if (!isArray(array)) {
+    if (!isEmberArray(array)) {
       return emberArray([array]);
     }
 

--- a/addon/helpers/contains.js
+++ b/addon/helpers/contains.js
@@ -1,6 +1,6 @@
 import { A as emberArray } from 'ember-array/utils';
 import get from 'ember-metal/get';
-import { typeOf } from 'ember-utils';
+import { isEmberArray } from 'ember-array/utils';
 import createNeedleHaystackHelper from '../-private/create-needle-haystack-helper';
 
 function _contains(needle, haystack) {
@@ -8,11 +8,11 @@ function _contains(needle, haystack) {
 }
 
 export function contains(needle, haystack) {
-  if (typeOf(haystack) !== 'array') {
+  if (!isEmberArray(haystack)) {
     return false;
   }
 
-  if (typeOf(needle) === 'array' && get(needle, 'length')) {
+  if (isEmberArray(needle) && get(needle, 'length')) {
     return needle.reduce((acc, val) => acc && _contains(val, haystack), true);
   }
 

--- a/addon/helpers/filter-by.js
+++ b/addon/helpers/filter-by.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import { filter } from 'ember-computed';
 import Helper from 'ember-helper';
 import get from 'ember-metal/get';
@@ -11,7 +11,7 @@ const { defineProperty } = Ember;
 
 export default Helper.extend({
   compute([byPath, value, array]) {
-    if (!isArray(array) && isArray(value)) {
+    if (!isEmberArray(array) && isEmberArray(value)) {
       array = value;
       value = undefined;
     }

--- a/addon/helpers/flatten.js
+++ b/addon/helpers/flatten.js
@@ -1,10 +1,10 @@
 import Helper from 'ember-helper';
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import observer from 'ember-metal/observer';
 import set from 'ember-metal/set';
 
 export function flatten(array) {
-  if (!isArray(array)) {
+  if (!isEmberArray(array)) {
     return array;
   }
 

--- a/addon/helpers/group-by.js
+++ b/addon/helpers/group-by.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import {
   A as emberArray,
-  isEmberArray as isArray
+  isEmberArray
 } from 'ember-array/utils';
 import computed from 'ember-computed';
 import Helper from 'ember-helper';
@@ -20,7 +20,7 @@ const groupFunction = function() {
     let groupName = get(item, byPath);
     let group = get(groups, groupName);
 
-    if (!isArray(group)) {
+    if (!isEmberArray(group)) {
       group = emberArray();
       set(groups, groupName, group);
     }

--- a/addon/helpers/join.js
+++ b/addon/helpers/join.js
@@ -1,11 +1,11 @@
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import Helper from 'ember-helper';
 import observer from 'ember-metal/observer';
 import set from 'ember-metal/set';
 
 export default Helper.extend({
   compute([separator, array]) {
-    if (isArray(separator)) {
+    if (isEmberArray(separator)) {
       array = separator;
       separator = ',';
     }

--- a/addon/helpers/object-at.js
+++ b/addon/helpers/object-at.js
@@ -1,12 +1,12 @@
 import Helper from 'ember-helper';
-import { A as emberArray, isEmberArray as isArray } from 'ember-array/utils';
+import { A as emberArray, isEmberArray } from 'ember-array/utils';
 import computed from 'ember-computed';
 import observer from 'ember-metal/observer';
 import get from 'ember-metal/get';
 import set from 'ember-metal/set';
 
 export function objectAt(index, array) {
-  if (!isArray(array)) {
+  if (!isEmberArray(array)) {
     return undefined;
   }
 

--- a/addon/helpers/reject-by.js
+++ b/addon/helpers/reject-by.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import { filter } from 'ember-computed';
 import Helper from 'ember-helper';
 import get from 'ember-metal/get';
@@ -12,7 +12,7 @@ const { defineProperty } = Ember;
 export default Helper.extend({
   compute([byPath, value, array]) {
 
-    if (!isArray(array) && isArray(value)) {
+    if (!isEmberArray(array) && isEmberArray(value)) {
       array = value;
       value = undefined;
     }

--- a/addon/helpers/reverse.js
+++ b/addon/helpers/reverse.js
@@ -1,6 +1,6 @@
 import {
   A as emberArray,
-  isEmberArray as isArray
+  isEmberArray
 } from 'ember-array/utils';
 import Helper from 'ember-helper';
 import observer from 'ember-metal/observer';
@@ -8,7 +8,7 @@ import set from 'ember-metal/set';
 
 export default Helper.extend({
   compute([array]) {
-    if (!isArray(array)) {
+    if (!isEmberArray(array)) {
       return [array];
     }
 

--- a/addon/helpers/shuffle.js
+++ b/addon/helpers/shuffle.js
@@ -1,6 +1,6 @@
 import {
   A as emberArray,
-  isEmberArray as isArray
+  isEmberArray
 } from 'ember-array/utils';
 import Helper from 'ember-helper';
 import observer from 'ember-metal/observer';
@@ -31,7 +31,7 @@ export default Helper.extend({
       random = undefined;
     }
 
-    if (!isArray(array)) {
+    if (!isEmberArray(array)) {
       return emberArray([array]);
     }
 

--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { isEmberArray as isArray } from 'ember-array/utils';
+import { isEmberArray } from 'ember-array/utils';
 import { sort } from 'ember-computed';
 import Helper from 'ember-helper';
 import get from 'ember-metal/get';
@@ -14,7 +14,7 @@ export default Helper.extend({
     let array = sortProps.pop();
     let [firstSortProp] = sortProps;
 
-    if (typeOf(firstSortProp) === 'function' || isArray(firstSortProp)) {
+    if (typeOf(firstSortProp) === 'function' || isEmberArray(firstSortProp)) {
       sortProps = firstSortProp;
     }
 

--- a/addon/helpers/without.js
+++ b/addon/helpers/without.js
@@ -1,6 +1,6 @@
 import {
   A as emberArray,
-  isEmberArray as isArray
+  isEmberArray
 } from 'ember-array/utils';
 import get from 'ember-metal/get';
 import { typeOf } from 'ember-utils';
@@ -11,7 +11,7 @@ function contains(needle, haystack) {
 }
 
 export function without(needle, haystack) {
-  if (!isArray(haystack)) {
+  if (!isEmberArray(haystack)) {
     return false;
   }
 


### PR DESCRIPTION
There were three different syntaxes being used:
```js
import { typeOf } from 'ember-utils';
typeOf(array) !== 'array';
```
```js
import { isEmberArray as isArray } from 'ember-array/utils';
isArray(array);
```
```js
import { isEmberArray } from 'ember-array/utils';
isEmberArray(array);
```

This standardizes to use the third syntax across all helpers.