### PR TITLE
[Docs] useDeepEqual is last parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ Returns the next element in the array given the current element. **Note:** Accep
 parameter, `useDeepEqual`, to flag whether a deep equal comparison should be performed.
 
 ```hbs
-<button onclick={{action (mut selectedItem) (next selectedItem useDeepEqual items)}}>Next</button>
+<button onclick={{action (mut selectedItem) (next selectedItem items useDeepEqual)}}>Next</button>
 ```
 
 **[⬆️ back to top](#available-helpers)**
@@ -697,7 +697,7 @@ Checks if the array has an element after the given element. **Note:** Accepts an
 parameter, `useDeepEqual`, to flag whether a deep equal comparison should be performed.
 
 ```hbs
-{{#if (has-next page useDeepEqual pages)}}
+{{#if (has-next page pages useDeepEqual)}}
   <button>Next</button>
 {{/if}}
 ```
@@ -709,7 +709,7 @@ Returns the previous element in the array given the current element. **Note:** A
 parameter, `useDeepEqual`, to flag whether a deep equal comparison should be performed.
 
 ```hbs
-<button onclick={{action (mut selectedItem) (previous selectedItem useDeepEqual items)}}>Previous</button>
+<button onclick={{action (mut selectedItem) (previous selectedItem items useDeepEqual)}}>Previous</button>
 ```
 
 **[⬆️ back to top](#available-helpers)**
@@ -719,7 +719,7 @@ Checks if the array has an element before the given element. **Note:** Accepts a
 parameter, `useDeepEqual`, to flag whether a deep equal comparison should be performed
 
 ```hbs
-{{#if (has-previous page useDeepEqual pages)}}
+{{#if (has-previous page pages useDeepEqual)}}
   <button>Previous</button>
 {{/if}}
 ```


### PR DESCRIPTION
Hi!

If I understand the source correctly `useDeepEqual` is the last parameter. In the README it was the second...

e.g. Source:

```javascript
export function next(currentValue, array, useDeepEqual = false) {
```