### PR TITLE
html-safe helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Capitalizes a string using `Ember.String.underscore`.
 **[⬆️ back to top](#available-helpers)**
 
 #### `html-safe`
-Mark a string as safe for unescaped output with Ember templates using `Ember.String.htmlSafe`
+Mark a string as safe for unescaped output with Ember templates using `Ember.String.htmlSafe`.
 
 ```hbs
 {{html-safe "<div>someString</div>"}}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For action helpers, this will mean better currying semantics:
   + [`dasherize`](#dasherize)
   + [`truncate`](#truncate)
   + [`underscore`](#underscore)
+  + [`html-safe`](#html-safe)
   + [`titleize`](#titleize)
   + [`w`](#w)
 * [Array](#array-helpers)
@@ -263,6 +264,15 @@ Capitalizes a string using `Ember.String.underscore`.
 ```hbs
 {{underscore "whatsThat"}}
 {{underscore phrase}}
+```
+**[⬆️ back to top](#available-helpers)**
+
+#### `html-safe`
+Mark a string as safe for unescaped output with Ember templates using `Ember.String.htmlSafe`
+
+```hbs
+{{html-safe "<div>someString</div>"}}
+{{html-safe unsafeString}}
 ```
 **[⬆️ back to top](#available-helpers)**
 

--- a/addon/helpers/html-safe.js
+++ b/addon/helpers/html-safe.js
@@ -1,0 +1,6 @@
+import { helper } from 'ember-helper';
+import { htmlSafe as _htmlSafe } from 'ember-string';
+import createStringHelperFunction from '../-private/create-string-helper';
+
+export const htmlSafe = createStringHelperFunction(_htmlSafe);
+export default helper(htmlSafe);

--- a/app/helpers/html-safe.js
+++ b/app/helpers/html-safe.js
@@ -1,0 +1,1 @@
+export { default, invoke } from 'ember-composable-helpers/helpers/html-safe';

--- a/app/helpers/html-safe.js
+++ b/app/helpers/html-safe.js
@@ -1,1 +1,1 @@
-export { default, invoke } from 'ember-composable-helpers/helpers/html-safe';
+export { default, htmlSafe } from 'ember-composable-helpers/helpers/html-safe';

--- a/tests/integration/helpers/html-safe-test.js
+++ b/tests/integration/helpers/html-safe-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('html-safe', 'Integration | Helper | {{html-safe}}', {
+  integration: true
+});
+
+test('It html-safes the html string', function(assert) {
+  this.render(hbs`{{html-safe '<h1>Hello World</h1>'}}`);
+
+  assert.equal(this.$('h1').text().trim(), 'Hello World', 'html string is correctly rendered');
+});
+
+test('It safely renders CSS classes from a property', function(assert) {
+  this.set('classes', 'error has-error');
+  this.render(hbs`<h1 class={{html-safe classes}}>Hello World</h1>`);
+
+  assert.equal(this.$('h1').text().trim(), 'Hello World', 'it renders');
+  assert.deepEqual(this.$('h1').attr('class').split(' ').sort(), ['error', 'has-error'].sort(), 'it has the correct CSS classes');
+});


### PR DESCRIPTION
Add support for Ember.String.htmlSafe. 

Usage: 

```hbs
<button class={{html-safe (join '  ' myClasses)}}>Custom Button</button>
```