### PR TITLE
Pass parameters to `optional` handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Toggles a boolean value.
 Allows for the passed in action to not exist.
 
 ```hbs
-<button {{action (optional handleClick)}}>Click Me</button>
+<button {{action (optional handleClick "foo")}}>Click Me</button>
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/addon/helpers/optional.js
+++ b/addon/helpers/optional.js
@@ -1,8 +1,8 @@
 import { helper } from 'ember-helper';
 
-export function optional([action]) {
+export function optional([action, ...args]) {
   if (typeof action === 'function') {
-    return action;
+    return action.bind(this, ...args);
   }
 
   return (i) => i;

--- a/tests/integration/helpers/optional-test.js
+++ b/tests/integration/helpers/optional-test.js
@@ -28,3 +28,14 @@ test('Works in a pipe', function(assert) {
     <button onclick={{action (pipe (action (optional handler)) (action "check")) 42}}></button> `);
   run(() => this.$('button').click());
 });
+
+test('Passes parameters', function(assert) {
+  assert.expect(2);
+  this.set('handler', (value1, value2) => {
+    assert.equal(value1, 42);
+    assert.equal(value2, 'foo');
+  });
+  this.render(hbs`
+    <button onclick={{action (action (optional handler 42 'foo'))}}></button> `);
+  run(() => this.$('button').click());
+});


### PR DESCRIPTION
## Changes proposed in this pull request

The existing `optional` helper doesn't pass any specified parameters to the action handler. This PR adds this feature.
