### PR TITLE
Allow empty values (null, undefined, etc)

### DIFF
--- a/addon/utils/titleize.js
+++ b/addon/utils/titleize.js
@@ -1,4 +1,10 @@
+import Ember from 'ember';
+
 export default function titleize(string = '') {
+  if (Ember.isBlank(string)) {
+    return '';
+  }
+  
   if (typeof string !== 'string') {
     throw new TypeError(`Expected a string, got a ${typeof string}`);
   }


### PR DESCRIPTION
We had a problem where titleize was passed in a null value from the database and it threw an error.

This is the only helper that will explicitly throw an error and stop the page from loading if the value isn't right. Another suggested changed would be 

```
if (typeof string !== 'string') {
  Ember.assert(`Expected a string, got a ${typeof string}`);
}
```

So an invalid value doesn't kill the page.

If you are okay with these changes, I'll write the tests and add the assert. 