### PR TITLE
Make compatible with Ember 2.9.0-beta.2+.

### DIFF
--- a/addon/-private/closure-action.js
+++ b/addon/-private/closure-action.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 
 const { __loader } = Ember;
 
-let ClosureActionModule;
+let ClosureActionModule = { ACTION: null };
 
 if ('ember-htmlbars/keywords/closure-action' in __loader.registry) {
   ClosureActionModule = __loader.require('ember-htmlbars/keywords/closure-action');
-} else {
+} else if ('ember-routing-htmlbars/keywords/closure-action' in __loader.registry) {
   ClosureActionModule = __loader.require('ember-routing-htmlbars/keywords/closure-action');
 }
 

--- a/addon/helpers/array.js
+++ b/addon/helpers/array.js
@@ -1,8 +1,9 @@
 import { helper } from 'ember-helper';
 import { A as emberArray } from 'ember-array/utils';
 
-export function array(params) {
-  return emberArray(params);
+export function array(params = []) {
+  // slice params to avoid mutating the provided params
+  return emberArray(params.slice());
 }
 
 export default helper(array);

--- a/addon/helpers/pipe-action.js
+++ b/addon/helpers/pipe-action.js
@@ -3,6 +3,8 @@ import { pipe } from './pipe';
 import ACTION from '../-private/closure-action';
 
 const closurePipe = pipe;
-closurePipe[ACTION] = true;
+if (ACTION) {
+  closurePipe[ACTION] = true;
+}
 
 export default helper(closurePipe);

--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -10,7 +10,9 @@ import { isEmpty, typeOf } from 'ember-utils';
 const { defineProperty } = Ember;
 
 export default Helper.extend({
-  compute(sortProps) {
+  compute(params) {
+    // slice params to avoid mutating the provided params
+    let sortProps = params.slice();
     let array = sortProps.pop();
     let [firstSortProp] = sortProps;
 

--- a/addon/helpers/toggle-action.js
+++ b/addon/helpers/toggle-action.js
@@ -3,6 +3,8 @@ import { toggle } from './toggle';
 import ACTION from '../-private/closure-action';
 
 const closureToggle = toggle;
-closureToggle[ACTION] = true;
+if (ACTION) {
+  closureToggle[ACTION] = true;
+}
 
 export default helper(closureToggle);


### PR DESCRIPTION
* Avoid mutating params/hash in helpers.
* Prevent errors when `ACTION` isn't needed.