### PR TITLE
Allow group-by with strings that contain punctuation

### DIFF
--- a/addon/helpers/group-by.js
+++ b/addon/helpers/group-by.js
@@ -22,7 +22,7 @@ const groupFunction = function() {
 
     if (!isEmberArray(group)) {
       group = emberArray();
-      set(groups, groupName, group);
+      groups[`${groupName}`] = group;
     }
 
     group.push(item);

--- a/tests/integration/helpers/group-by-test.js
+++ b/tests/integration/helpers/group-by-test.js
@@ -47,3 +47,22 @@ test('It watches for changes', function(assert) {
 
   assert.equal(this.$().text().trim(), 'aabbccd', 'aabbccd is the right order');
 });
+
+test('It groups by properties that contain punctuation', function(assert) {
+  this.set('array', emberArray([
+    { category: 'a, inc.', name: 'a' },
+    { category: 'b, co.', name: 'b' },
+    { category: 'c. l.l.p.', name: 'c' },
+    { category: 'd & co.', name: 'd' }
+  ]));
+
+  this.render(hbs`
+    {{~#each-in (group-by 'category' array) as |category entries|~}}
+      {{~category~}}
+      {{~#each entries as |entry|~}}{{~entry.name~}}{{~/each~}}
+    {{~/each-in~}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'a, inc.ab, co.bc. l.l.p.cd & co.d', 'a, inc.ab, co.bc. l.l.p.cd & co.d is the right output');
+});
+


### PR DESCRIPTION
<!-- BUG TEMPLATE -->
## Version

1.1.1
## Test Case

See [this Twiddle](https://ember-twiddle.com/9357cee3702bea9893c18ad5003240b3?openFiles=routes.index.js%2C) for a broken use-case.
## Steps to reproduce

See Twiddle above. Add/remove period `.` from `supplierName` attribute of one of the contract objects in the `index` route.
## Expected Behavior

The supplierName should appear as a string in the template.
## Actual Behavior

If the supplierName contains a period, it cannot be set as a key. Ember Composable Helpers throws Ember Error: `Error: Property set failed: You passed an empty path`

---

In `ember-composable-helpers/addon/helpers/group-by.js`, changing the following...

```
    if (!isEmberArray(group)) {
      group = emberArray();
      set(groups, groupName, group);
    }
```

...to...

```
    if (!isEmberArray(group)) {
      group = emberArray();
      groups[`${groupName}`] = group;
    }
```

...will fix the problem and passes tests.
