### PR TITLE
Use Ember.isEqual

### DIFF
--- a/addon/helpers/filter-by.js
+++ b/addon/helpers/filter-by.js
@@ -6,6 +6,7 @@ import get from 'ember-metal/get';
 import observer from 'ember-metal/observer';
 import set from 'ember-metal/set';
 import { isEmpty, isPresent } from 'ember-utils';
+import isEqual from '../utils/is-equal';
 
 const { defineProperty } = Ember;
 
@@ -38,7 +39,7 @@ export default Helper.extend({
       if (typeof value === 'function') {
         filterFn = (item) => value(get(item, byPath));
       } else {
-        filterFn = (item) => get(item, byPath) === value;
+        filterFn = (item) => isEqual(get(item, byPath), value);
       }
     } else {
       filterFn = (item) => isPresent(get(item, byPath));

--- a/addon/helpers/reject-by.js
+++ b/addon/helpers/reject-by.js
@@ -6,6 +6,7 @@ import get from 'ember-metal/get';
 import observer from 'ember-metal/observer';
 import set from 'ember-metal/set';
 import { isEmpty, isPresent } from 'ember-utils';
+import isEqual from '../utils/is-equal';
 
 const { defineProperty } = Ember;
 
@@ -39,7 +40,7 @@ export default Helper.extend({
       if (typeof value === 'function') {
         filterFn = (item) => !value(get(item, byPath));
       } else {
-        filterFn = (item) => get(item, byPath) !== value;
+        filterFn = (item) => !isEqual(get(item, byPath), value);
       }
     } else {
       filterFn = (item) => isEmpty(get(item, byPath));

--- a/addon/utils/is-equal.js
+++ b/addon/utils/is-equal.js
@@ -5,6 +5,6 @@ export default function isEqual(firstValue, secondValue, useDeepEqual = false) {
   if (useDeepEqual) {
     return JSON.stringify(firstValue) === JSON.stringify(secondValue);
   } else {
-    return emberIsEqual(firstValue, secondValue);
+    return emberIsEqual(firstValue, secondValue) || emberIsEqual(secondValue, firstValue);
   }
 }

--- a/addon/utils/is-equal.js
+++ b/addon/utils/is-equal.js
@@ -1,7 +1,10 @@
+import Ember from 'ember';
+const { isEqual: emberIsEqual } = Ember;
+
 export default function isEqual(firstValue, secondValue, useDeepEqual = false) {
   if (useDeepEqual) {
     return JSON.stringify(firstValue) === JSON.stringify(secondValue);
   } else {
-    return firstValue === secondValue;
+    return emberIsEqual(firstValue, secondValue);
   }
 }

--- a/tests/integration/helpers/filter-by-test.js
+++ b/tests/integration/helpers/filter-by-test.js
@@ -139,3 +139,25 @@ test('It can be passed an action', function(assert) {
 
   assert.equal(this.$().text().trim(), 'ac', 'b is filtered out');
 });
+
+test('It respects objects that implement isEqual interface', function(assert) {
+  this.set('firstTarget', {
+    isEqual(value) {
+      return value === 1;
+    }
+  });
+
+  this.set('array', emberArray([
+    { foo: 1, name: 'a' },
+    { foo: 2, name: 'b' },
+    { foo: 3, name: 'c' }
+  ]));
+
+  this.render(hbs`
+    {{~#each (filter-by 'foo' firstTarget array) as |item|~}}
+      {{~item.name~}}
+    {{~/each~}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'a', 'b and c are filtered out');
+});

--- a/tests/integration/helpers/reject-by-test.js
+++ b/tests/integration/helpers/reject-by-test.js
@@ -99,3 +99,25 @@ test('It can be passed an action', function(assert) {
 
   assert.equal(this.$().text().trim(), 'ac', 'b is filtered out');
 });
+
+test('It respects objects that implement isEqual interface', function(assert) {
+  this.set('firstTarget', {
+    isEqual(value) {
+      return value === 1;
+    }
+  });
+
+  this.set('array', emberArray([
+    { foo: 1, name: 'a' },
+    { foo: 2, name: 'b' },
+    { foo: 3, name: 'c' }
+  ]));
+
+  this.render(hbs`
+    {{~#each (reject-by 'foo' firstTarget array) as |item|~}}
+      {{~item.name~}}
+    {{~/each~}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'bc', 'a is filtered out');
+});

--- a/tests/unit/utils/is-equal-test.js
+++ b/tests/unit/utils/is-equal-test.js
@@ -43,13 +43,24 @@ let testData = [
     expected: true
   },
   {
-    label: 'Ember.isEqual Support',
+    label: 'Ember.isEqual applied to firstValue',
     firstValue: EmberObject.extend({
       isEqual(value) {
         return this.get('value') === value;
       }
     }).create({ 'value': 10 }),
     secondValue: 10,
+    useDeepEqual: false,
+    expected: true
+  },
+  {
+    label: 'Ember.isEqual applied to secondValue',
+    firstValue: 10,
+    secondValue: EmberObject.extend({
+      isEqual(value) {
+        return this.get('value') === value;
+      }
+    }).create({ 'value': 10 }),
     useDeepEqual: false,
     expected: true
   }

--- a/tests/unit/utils/is-equal-test.js
+++ b/tests/unit/utils/is-equal-test.js
@@ -41,6 +41,17 @@ let testData = [
     secondValue: 'a',
     useDeepEqual: false,
     expected: true
+  },
+  {
+    label: 'Ember.isEqual Support',
+    firstValue: EmberObject.extend({
+      isEqual(value) {
+        return this.get('value') === value;
+      }
+    }).create({ 'value': 10 }),
+    secondValue: 10,
+    useDeepEqual: false,
+    expected: true
   }
 ];
 


### PR DESCRIPTION
This PR modifies `utils/isEqual` to use `Ember.isEqual`. `Ember.isEqual` only checks if the first argument implements `isEqual` interface, so I have to check twice: first for second argument against first, followed by first argument against second.

Closes #235 