### PR TITLE
Fix pipe readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ For action helpers, this will mean better currying semantics:
 Pipes the return values of actions in a sequence of actions. This is useful to compose a pipeline of actions, so each action can do only one thing.
 
 ```hbs
-<button {{action (pipe addToCart purchase redirectToThankYouPage) item}}>
+
+<button {{ action ( pipe ( action 'addToCart') (action 'purchase') ( action 'redirectToThankYouPage' )) item}}>
   1-Click Buy
 </button>
 ```


### PR DESCRIPTION
## Changes proposed in this pull request

Hi, 

This is an small PR related to the example you have in the README about the `pipe` helper. using the helper with this syntax  `{{action (pipe addToCart purchase redirectToThankYouPage) item}}` doesn't work an produce the following error:

`pipe.js:25 Uncaught TypeError: Cannot read property 'apply' of undefined(…)`

Looking at you tests, it seems that the correct way to use the helper is:

`{{ action ( pipe ( action 'addToCart') (action 'purchase') ( action 'redirectToThankYouPage' )) item}}`

I am just trying to avoid frustration when someone use the addon for the first time. 


BTW, I am using the addon  with Ember 2.8.0

Regards,
Daniel.
