### PR TITLE
Fix truthy/falsy checks in filter-by and reject-by when value is omitted

### DIFF
--- a/addon/helpers/filter-by.js
+++ b/addon/helpers/filter-by.js
@@ -42,7 +42,7 @@ export default Helper.extend({
         filterFn = (item) => isEqual(get(item, byPath), value);
       }
     } else {
-      filterFn = (item) => isPresent(get(item, byPath));
+      filterFn = (item) => !!get(item, byPath);
     }
 
     let cp = filter(`array.@each.${byPath}`, filterFn);

--- a/addon/helpers/reject-by.js
+++ b/addon/helpers/reject-by.js
@@ -43,7 +43,7 @@ export default Helper.extend({
         filterFn = (item) => !isEqual(get(item, byPath), value);
       }
     } else {
-      filterFn = (item) => isEmpty(get(item, byPath));
+      filterFn = (item) => !get(item, byPath);
     }
 
     let cp = filter(`array.@each.${byPath}`, filterFn);

--- a/tests/integration/helpers/filter-by-test.js
+++ b/tests/integration/helpers/filter-by-test.js
@@ -26,11 +26,16 @@ test('It filters by value', function(assert) {
 
 test('It filters by truthiness', function(assert) {
   this.set('array', emberArray([
-    { foo: 'x',  name: 'a' },
+    { foo: 'x', name: 'a' },
     { foo: undefined, name: 'b' },
-    { foo: 1,  name: 'c' },
-    { foo: null,  name: 'd' },
-    { foo: [1, 2, 3],  name: 'e' }
+    { foo: 1, name: 'c' },
+    { foo: null, name: 'd' },
+    { foo: [1, 2, 3], name: 'e' },
+    { foo: false, name: 'f' },
+    { foo: 0, name: 'g' },
+    { foo: '', name: 'h' },
+    { foo: NaN, name: 'i' },
+    { foo: [], name: 'j' }
   ]));
 
   this.render(hbs`
@@ -39,7 +44,7 @@ test('It filters by truthiness', function(assert) {
     {{~/each~}}
   `);
 
-  assert.equal(this.$().text().trim(), 'ace', 'b and d are filtered out');
+  assert.equal(this.$().text().trim(), 'acej', 'b, d, f, g, h and i are filtered out');
 });
 
 test('It recomputes the filter if array changes', function(assert) {
@@ -117,9 +122,11 @@ test('It recomputes the filter with no value', function(assert) {
     {{~/each~}}
   `);
 
+  assert.equal(this.$().text().trim(), 'ac', 'ac is shown');
+
   run(() => set(array.objectAt(1), 'foo', true));
 
-  assert.equal(this.$().text().trim(), 'abc', 'abc is shown');
+  assert.equal(this.$().text().trim(), 'abc', 'b is added');
 });
 
 test('It can be passed an action', function(assert) {

--- a/tests/integration/helpers/reject-by-test.js
+++ b/tests/integration/helpers/reject-by-test.js
@@ -26,11 +26,16 @@ test('It reject by value', function(assert) {
 
 test('It rejects by truthiness', function(assert) {
   this.set('array', emberArray([
-    { foo: 'x',  name: 'a' },
+    { foo: 'x', name: 'a' },
     { foo: undefined, name: 'b' },
-    { foo: 1,  name: 'c' },
-    { foo: null,  name: 'd' },
-    { foo: [1, 2, 3],  name: 'e' }
+    { foo: 1, name: 'c' },
+    { foo: null, name: 'd' },
+    { foo: [1, 2, 3], name: 'e' },
+    { foo: false, name: 'f' },
+    { foo: 0, name: 'g' },
+    { foo: '', name: 'h' },
+    { foo: NaN, name: 'i' },
+    { foo: [], name: 'j' }
   ]));
 
   this.render(hbs`
@@ -39,7 +44,7 @@ test('It rejects by truthiness', function(assert) {
     {{~/each~}}
   `);
 
-  assert.equal(this.$().text().trim(), 'bd', 'a, c and e are filtered out');
+  assert.equal(this.$().text().trim(), 'bdfghi', 'a, c, e and j are filtered out');
 });
 
 test('It recomputes the filter if array changes', function(assert) {
@@ -72,14 +77,16 @@ test('It recomputes the filter if a value under given path changes', function(as
   this.set('array', array);
 
   this.render(hbs`
-    {{~#each (reject-by 'foo' true array) as |item|~}}
+    {{~#each (reject-by 'foo' array) as |item|~}}
       {{~item.name~}}
     {{~/each~}}
   `);
 
+  assert.equal(this.$().text().trim(), 'ac', 'ac is shown');
+
   run(() => set(array.objectAt(1), 'foo', false));
 
-  assert.equal(this.$().text().trim(), 'abc', 'b is shown');
+  assert.equal(this.$().text().trim(), 'abc', 'b is added');
 });
 
 test('It can be passed an action', function(assert) {


### PR DESCRIPTION
Addressing #98. It was closed but has not been fixed.

According to documentation:
- `filter-by`: `If you omit the second argument it will test if the property is truthy.`
- `reject-by`: `If you omit the third argument it will test if the property is falsey.`

Currently the checks are done using `Ember.isPresent()` and `Ember.isEmpty()` which don't really test truthiness and falsiness. For example, `Ember.isPresent(false)` returns `true` which is not the desired result.

I added failing tests for some falsy values (`false`, `0`, `''` and `NaN`) and one truthy value (`[]`), and changed the implementation to using plain JavaScript boolean operators.

Also the word `third` seems incorrect so I changed it to `second`.