### PR TITLE
Add failing test to queue related to conditional actions

### DIFF
--- a/tests/integration/helpers/queue-test.js
+++ b/tests/integration/helpers/queue-test.js
@@ -16,9 +16,10 @@ test('it queues actions', function(assert) {
   this.on('process', (x) => this.set('value', x * x));
   this.on('undoAThing', () => null);
   this.set('value', 2);
+  this.set('doNotExecute', false);
   this.render(hbs`
     <p>{{value}}</p>
-    <button {{action (queue (action "doAThing") (action "process") (action "undoAThing")) value}}>
+    <button {{action (queue (action "doAThing") (action "process") (if doNotExecute (action "undoAThing"))) value}}>
       Calculate
     </button>
   `);


### PR DESCRIPTION
Queue helper does not support conditional actions.

I'm not sure if it's a bug with EmberJS or ember-composable-helpers...