### PR TITLE
Add an upgrade guide from 1.x to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ For action helpers, this will mean better currying semantics:
 </button>
 ```
 
+## Upgrade Guide
+For help upgrading between major versions, check out the [upgrading documentation](https://github.com/DockYard/ember-composable-helpers/blob/master/UPGRADING.md).
+
 ## Available helpers
 
 * [Action](#action-helpers)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,22 @@
+# Upgrade Guide
+
+## 1.x -> 2.x
+The string helpers were broken out into a
+[new project](https://github.com/romulomachado/ember-cli-string-helpers).
+
+* String
+  + `camelize`
+  + `capitalize`
+  + `classify`
+  + `dasherize`
+  + `truncate`
+  + `underscore`
+  + `html-safe`
+  + `titleize`
+  + `w`
+
+If you project relied on any of these helpers in 1.x, you'll need to run:
+
+```
+ember install ember-cli-string-helpers
+```


### PR DESCRIPTION
I recently was upgrading a project from 1.x to 2.x and resorted to the commit history to understand the reason the major version was bumped. This PR adds a simple doc for folks to see what changed.

[rendered](https://github.com/blimmer/ember-composable-helpers/blob/790f9900e2a3c7f7e79032e00994f56ac2188092/UPGRADING.md)