### PR TITLE
enhance slice helper to also support passing only 2 arguments

### DIFF
--- a/addon/helpers/slice.js
+++ b/addon/helpers/slice.js
@@ -3,9 +3,20 @@ import observer from 'ember-metal/observer';
 import set from 'ember-metal/set';
 
 export default Helper.extend({
-  compute([start, end, array]) {
+  compute(args) {
+    let array = args[args.length - 1];
+    let parsedArgs = [];
+
+    if (args.length === 3) {
+      parsedArgs = [ args[0], args[1] ];
+    }
+
+    if (args.length === 2) {
+      parsedArgs = [ args[0] ];
+    }
+
     set(this, 'array', array);
-    return array.slice(start, end);
+    return array.slice(...parsedArgs);
   },
 
   arrayContentDidChange: observer('array.[]', function() {

--- a/tests/integration/helpers/slice-test.js
+++ b/tests/integration/helpers/slice-test.js
@@ -32,3 +32,19 @@ test('It recomputes the slice if an item in the array changes', function(assert)
 
   assert.equal(this.$().text().trim(), '4,5', 'sliced values');
 });
+
+test('It slices an array with only two params (start, array) passed to the helper', function(assert) {
+  this.set('array', emberArray([2, 4, 6]));
+
+  this.render(hbs`
+    {{slice 1 array}}
+  `);
+
+  assert.equal(this.$().text().trim(), '4,6', 'sliced values');
+
+  this.render(hbs`
+    {{slice -1 array}}
+  `);
+
+  assert.equal(this.$().text().trim(), '6', 'sliced values');
+});


### PR DESCRIPTION
In order to support native ``` slice ``` behaviour like this:

```
a = [1,2,3,4]
a.slice(-1) -> [4]
```
Until now the slice helper expected always ```start```, ```stop``` and ```array``` being passed to the helper like this ```{{slice 0 2 array}}```.

Now it is possible to use the slice helper also like this:
```{{slice -1 array}}```