### PR TITLE
Only install ember-cli-shims if it doesn't exist

### DIFF
--- a/blueprints/ember-composable-helpers/index.js
+++ b/blueprints/ember-composable-helpers/index.js
@@ -1,7 +1,9 @@
 module.exports = {
   normalizeEntityName: function() {},
 
-  afterInstall: function() {
-    return this.addBowerPackageToProject('ember-cli-shims', '~0.1.1');
+  afterInstall: function(options) {
+    if (!('ember-cli-shims' in options.project.addonPackages)) {
+      return this.addBowerPackageToProject('ember-cli-shims', '~0.1.1');
+    }
   }
 };


### PR DESCRIPTION
## Changes proposed in this pull request

Check first to see if ember-cli-shims is installed as a package (which
it is after ember-cli 2.11.

Closes #254 

Some caveats:
1) This is the only idea I had for preventing an unnecessary bower install. It might be a bad one.
2) I don't have any knowledge of the `options` parameter I used to detect the installation of `ember-cli-shims` - passing it in is part of the API docs at https://ember-cli.com/api/classes/Blueprint.html but there are no details.
3) I don't think there is a way to test the blueprint.