### PR TITLE
Read options from parent or app

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ module.exports = {
     }
 
     this.app = app;
-    this.app.options = this.app.options || {};
 
-    var config = this.app.options[this.name] || {};
+    var addonOptions = (this.parent && this.parent.options) || (this.app && this.app.options) || {};
+    var config = addonOptions[this.name] || {};
     this.whitelist = this.generateWhitelist(config);
     this.blacklist = this.generateBlacklist(config);
   },


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->

The PR makes ember-composable-helpers read its options from either `this.parent` or `this.app`.

The "issue" is that relying only on `this.app` makes it impossible to configure from within an engine.
The changed code is copied from [`ember-cli-babel`](https://github.com/babel/ember-cli-babel/blob/master/index.js#L137).
