### PR TITLE
feat(tree-shaking): remove unused helpers from app tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,11 @@ module.exports = {
     return this.filterHelpers(tree, new RegExp(moduleRegexp, 'i'));
   },
 
+  treeForApp: function() {
+    var tree = this._super.treeForApp.apply(this, arguments);
+    return this.filterHelpers(tree, /^helpers\//i);
+  },
+
   filterHelpers: function(tree, regex) {
     var whitelist = this.whitelist;
     var blacklist = this.blacklist;


### PR DESCRIPTION
The `only` and `except` configuration options for tree-shaking affect the host app's vendor.js but not the application js.

We (Square) noticed this by installing the addon in an empty app and noticing that the application js file increased by 12kb regardless of how we configured tree-shaking.