### PR TITLE
Remove reexports of nonexistent names

### DIFF
--- a/app/helpers/compact.js
+++ b/app/helpers/compact.js
@@ -1,1 +1,1 @@
-export { default, compact } from 'ember-composable-helpers/helpers/compact';
+export { default } from 'ember-composable-helpers/helpers/compact';

--- a/app/helpers/drop.js
+++ b/app/helpers/drop.js
@@ -1,1 +1,1 @@
-export { default, drop } from 'ember-composable-helpers/helpers/drop';
+export { default } from 'ember-composable-helpers/helpers/drop';

--- a/app/helpers/filter-by.js
+++ b/app/helpers/filter-by.js
@@ -1,1 +1,1 @@
-export { default, filterBy } from 'ember-composable-helpers/helpers/filter-by';
+export { default } from 'ember-composable-helpers/helpers/filter-by';

--- a/app/helpers/filter.js
+++ b/app/helpers/filter.js
@@ -1,1 +1,1 @@
-export { default, filter } from 'ember-composable-helpers/helpers/filter';
+export { default } from 'ember-composable-helpers/helpers/filter';

--- a/app/helpers/find-by.js
+++ b/app/helpers/find-by.js
@@ -1,1 +1,1 @@
-export { default, findBy } from 'ember-composable-helpers/helpers/find-by';
+export { default } from 'ember-composable-helpers/helpers/find-by';

--- a/app/helpers/group-by.js
+++ b/app/helpers/group-by.js
@@ -1,1 +1,1 @@
-export { default, groupBy } from 'ember-composable-helpers/helpers/group-by';
+export { default } from 'ember-composable-helpers/helpers/group-by';

--- a/app/helpers/intersect.js
+++ b/app/helpers/intersect.js
@@ -1,1 +1,1 @@
-export { default, intersect } from 'ember-composable-helpers/helpers/intersect';
+export { default } from 'ember-composable-helpers/helpers/intersect';

--- a/app/helpers/join.js
+++ b/app/helpers/join.js
@@ -1,1 +1,1 @@
-export { default, join } from 'ember-composable-helpers/helpers/join';
+export { default } from 'ember-composable-helpers/helpers/join';

--- a/app/helpers/map-by.js
+++ b/app/helpers/map-by.js
@@ -1,1 +1,1 @@
-export { default, mapBy } from 'ember-composable-helpers/helpers/map-by';
+export { default } from 'ember-composable-helpers/helpers/map-by';

--- a/app/helpers/map.js
+++ b/app/helpers/map.js
@@ -1,1 +1,1 @@
-export { default, map } from 'ember-composable-helpers/helpers/map';
+export { default } from 'ember-composable-helpers/helpers/map';

--- a/app/helpers/reduce.js
+++ b/app/helpers/reduce.js
@@ -1,1 +1,1 @@
-export { default, reduce } from 'ember-composable-helpers/helpers/reduce';
+export { default } from 'ember-composable-helpers/helpers/reduce';

--- a/app/helpers/reject-by.js
+++ b/app/helpers/reject-by.js
@@ -1,1 +1,1 @@
-export { default, rejectBy } from 'ember-composable-helpers/helpers/reject-by';
+export { default } from 'ember-composable-helpers/helpers/reject-by';

--- a/app/helpers/reverse.js
+++ b/app/helpers/reverse.js
@@ -1,1 +1,1 @@
-export { default, reverse } from 'ember-composable-helpers/helpers/reverse';
+export { default } from 'ember-composable-helpers/helpers/reverse';

--- a/app/helpers/slice.js
+++ b/app/helpers/slice.js
@@ -1,1 +1,1 @@
-export { default, slice } from 'ember-composable-helpers/helpers/slice';
+export { default } from 'ember-composable-helpers/helpers/slice';

--- a/app/helpers/sort-by.js
+++ b/app/helpers/sort-by.js
@@ -1,1 +1,1 @@
-export { default, sortBy } from 'ember-composable-helpers/helpers/sort-by';
+export { default } from 'ember-composable-helpers/helpers/sort-by';

--- a/app/helpers/take.js
+++ b/app/helpers/take.js
@@ -1,1 +1,1 @@
-export { default, take } from 'ember-composable-helpers/helpers/take';
+export { default } from 'ember-composable-helpers/helpers/take';

--- a/app/helpers/union.js
+++ b/app/helpers/union.js
@@ -1,1 +1,1 @@
-export { default, union } from 'ember-composable-helpers/helpers/union';
+export { default } from 'ember-composable-helpers/helpers/union';


### PR DESCRIPTION
These things are all reexports of names that don't actually exist. If anybody tries to use these, they get an error. But almost certainly nobody tries to use these, because they shouldn't anyway. They should import the originals directly out of the addon's namespace, not the app's namespace.

I noticed this issue because I'm experimenting with more automatic dependency traversal, and these bad links generate warnings.
