### PR TITLE
Adding ember-cli-shims to bower is not longer needed nor advised.

### DIFF
--- a/blueprints/ember-composable-helpers/index.js
+++ b/blueprints/ember-composable-helpers/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-  normalizeEntityName: function() {},
-
-  afterInstall: function(options) {
-    if (!('ember-cli-shims' in options.project.addonPackages)) {
-      return this.addBowerPackageToProject('ember-cli-shims', '~0.1.1');
-    }
-  }
-};


### PR DESCRIPTION
Closes #303

## Changes proposed in this pull request
Removes blueprint that adds `ember-cli-shims` to the bower.json
