### PR TITLE
fix unused helper stripping

### DIFF
--- a/lib/strip-bad-reexports.js
+++ b/lib/strip-bad-reexports.js
@@ -1,0 +1,53 @@
+/* eslint-env node */
+const resolve = require('resolve');
+const { transform } = require('@babel/core');
+const Funnel = require('broccoli-funnel');
+const { writeFileSync, readFileSync, existsSync, unlinkSync } = require('fs');
+const { join } = require('path');
+
+
+module.exports = class StripBadReexports extends Funnel {
+  constructor(tree, files) {
+    super(tree);
+    this.filesToStrip = files;
+  }
+  build() {
+    super.build();
+    for (let file of this.filesToStrip) {
+      let srcFile = join(this.inputPaths[0], file);
+      if (!existsSync(srcFile)) {
+        continue;
+      }
+      let src = readFileSync(srcFile, 'utf8');
+      let plugins = [[stripBadReexportsTransform, { resolveBase: this.outputPath }]];
+      let destFile = join(this.outputPath, file);
+      unlinkSync(destFile);
+      writeFileSync(destFile, transform(src, { plugins }).code);
+    }
+  }
+  shouldLinkRoots() {
+    // We want to force funnel to copy things rather than just linking the whole
+    // directory, because we're planning to mutate it.
+    return false;
+  }
+}
+
+function stripBadReexportsTransform() {
+  return {
+    visitor: {
+      ExportNamedDeclaration(path, state) {
+        if (
+          path.node.source &&
+          path.node.source.type === 'StringLiteral'
+        ) {
+          try {
+            resolve.sync(path.node.source.value, { basedir: state.opts.resolveBase });
+          } catch (err) {
+            path.remove();
+          }
+        }
+      },
+    },
+  };
+}
+

--- a/package.json
+++ b/package.json
@@ -75,8 +75,10 @@
     "test": "tests"
   },
   "dependencies": {
-    "broccoli-funnel": "^1.0.1",
-    "ember-cli-babel": "^7.1.0"
+    "@babel/core": "^7.0.0",
+    "broccoli-funnel": "2.0.1",
+    "ember-cli-babel": "^7.1.0",
+    "resolve": "^1.10.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,25 @@ broccoli-funnel-reducer@^1.0.0:
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
   integrity sha1-ETZbKnha7JsXlyo234fu8kxcwOo=
 
+broccoli-funnel@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
+  integrity sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"


### PR DESCRIPTION
This fixes #308.

As there is no existing test infrastructure for running builds with different build-time options, there was not a good place to put a test so I didn't make one.

The changes here fix both parts of the problem reported in #308.

 - in the addon tree, we need to rewrite the `index.js` file so it stops trying to import helpers that have already been removed.
 - in the app tree, we need to remove the files that reexport removed helpers.
