### PR TITLE
allow `{{take}}` to be used with null arrays

### DIFF
--- a/addon/helpers/take.js
+++ b/addon/helpers/take.js
@@ -4,6 +4,9 @@ import { set } from '@ember/object';
 
 export default Helper.extend({
   compute([takeAmount, array]) {
+    if (!array) {
+      array = [];
+    }
     set(this, 'array', array);
     return array.slice(0, takeAmount);
   },

--- a/tests/integration/helpers/take-test.js
+++ b/tests/integration/helpers/take-test.js
@@ -34,4 +34,17 @@ module('Integration | Helper | {{take}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '01', '0 and 1 are kept');
   });
+
+  test('It allows null arrays', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{~#each (take 2 array) as |n|~}}
+        {{n}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render');
+  });
 });


### PR DESCRIPTION
This avoids `Cannot read property 'slice' of null` when you use `{{take}}` with a null array.