### PR TITLE
Handle null array in map-by

### DIFF
--- a/addon/helpers/map-by.js
+++ b/addon/helpers/map-by.js
@@ -5,6 +5,9 @@ function mapBy([byPath, array]) {
   if (isEmpty(byPath)) {
     return [];
   }
+  if (!array) {
+    array = [];
+  }
 
   return array.map(item => item[byPath]);
 }

--- a/tests/integration/helpers/map-by-test.js
+++ b/tests/integration/helpers/map-by-test.js
@@ -64,4 +64,16 @@ module('Integration | Helper | {{map-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '123', '123 is displayed');
   });
+
+  test('It allows null arrays', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      {{~#each (map-by 'name' array) as |name|~}}
+        {{~name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '', 'this is all that will render, but there is no error');
+  });
 });


### PR DESCRIPTION
This avoids "array is null" when you use {{map-by}} with a null array.

This was broken by #323 when it was updated to `map` on the array directly instead of using the Ember computed `mapBy`.