### PR TITLE
Handle null arrays for all helpers

### DIFF
--- a/addon/helpers/drop.js
+++ b/addon/helpers/drop.js
@@ -1,6 +1,9 @@
 import { helper } from '@ember/component/helper';
 
 function drop([dropAmount, array]) {
+  if (!array) {
+    array = [];
+  }
   return array.slice(dropAmount);
 }
 

--- a/addon/helpers/filter.js
+++ b/addon/helpers/filter.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 import { isEmpty } from '@ember/utils';
 
 function filter([callback, array]) {
-  if (isEmpty(callback)) {
+  if (isEmpty(callback) || !array) {
     return [];
   }
 

--- a/addon/helpers/has-next.js
+++ b/addon/helpers/has-next.js
@@ -5,6 +5,9 @@ import isEqual from '../utils/is-equal';
 import getValueArrayAndUseDeepEqualFromParams from '../-private/get-value-array-and-use-deep-equal-from-params';
 
 function hasNext(currentValue, array, useDeepEqual = false) {
+  if (!array) {
+    array = [];
+  }
   let nextValue = next(currentValue, array, useDeepEqual);
   let isNotSameValue = !isEqual(nextValue, currentValue, useDeepEqual);
 

--- a/addon/helpers/has-previous.js
+++ b/addon/helpers/has-previous.js
@@ -5,6 +5,9 @@ import isEqual from '../utils/is-equal';
 import getValueArrayAndUseDeepEqualFromParams from '../-private/get-value-array-and-use-deep-equal-from-params';
 
 function hasPrevious(currentValue, array, useDeepEqual = false) {
+  if (!array) {
+    array = [];
+  }
   let previousValue = previous(currentValue, array, useDeepEqual);
   let isNotSameValue = !isEqual(previousValue, currentValue, useDeepEqual);
 

--- a/addon/helpers/intersect.js
+++ b/addon/helpers/intersect.js
@@ -1,8 +1,12 @@
 import { helper } from '@ember/component/helper';
+import { isArray as isEmberArray } from '@ember/array';
 
 export function intersect([...arrays]) {
+  let confirmedArrays = arrays.map(array => {
+    return isEmberArray(array) ? array : [];
+  });
   // copied from https://github.com/emberjs/ember.js/blob/315ec6472ff542ac714432036cc96fe4bd62bd1f/packages/%40ember/object/lib/computed/reduce_computed_macros.js#L1063-L1100
-  let results = arrays.pop().filter(candidate => {
+  let results = confirmedArrays.pop().filter(candidate => {
     for (let i = 0; i < arrays.length; i++) {
       let found = false;
       let array = arrays[i];

--- a/addon/helpers/join.js
+++ b/addon/helpers/join.js
@@ -2,6 +2,9 @@ import { helper } from '@ember/component/helper';
 import { isArray as isEmberArray } from '@ember/array';
 
 function join([separator, array]) {
+  if (!array) {
+    array = [];
+  }
   if (isEmberArray(separator)) {
     array = separator;
     separator = ',';

--- a/addon/helpers/next.js
+++ b/addon/helpers/next.js
@@ -5,6 +5,9 @@ import { A as emberArray } from '@ember/array';
 import getValueArrayAndUseDeepEqualFromParams from '../-private/get-value-array-and-use-deep-equal-from-params';
 
 export function next(currentValue, array, useDeepEqual = false) {
+  if (!array) {
+    array = [];
+  }
   let currentIndex = getIndex(array, currentValue, useDeepEqual);
   let lastIndex = array.length - 1;
 

--- a/addon/helpers/reject-by.js
+++ b/addon/helpers/reject-by.js
@@ -9,6 +9,9 @@ function rejectBy([byPath, value, array]) {
     array = value;
     value = undefined;
   }
+  if (!array) {
+    array = [];
+  }
 
   let filterFn;
 

--- a/addon/helpers/slice.js
+++ b/addon/helpers/slice.js
@@ -1,6 +1,9 @@
 import { helper } from '@ember/component/helper';
 
 function slice([start, end, array]) {
+  if (!array) {
+    array = [];
+  }
   return array.slice(start, end);
 }
 

--- a/tests/integration/helpers/append-test.js
+++ b/tests/integration/helpers/append-test.js
@@ -52,4 +52,16 @@ module('Integration | Helper | {{append}}', function(hooks) {
     run(() => this.get('odds').pushObject(7));
     assert.equal(find('*').textContent.trim(), '13572', 'new value is added');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      {{~#each (append 1 array) as |value|~}}
+        {{~value~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '1', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/chunk-test.js
+++ b/tests/integration/helpers/chunk-test.js
@@ -121,4 +121,17 @@ module('Integration | Helper | {{chunk}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '12 34 somenew items', 'updated chunked arrays are displayed');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (chunk array 1) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/compact-test.js
+++ b/tests/integration/helpers/compact-test.js
@@ -60,4 +60,17 @@ module('Integration | Helper | {{compact}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '1253', 'null is removed');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (compact array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/contains-test.js
+++ b/tests/integration/helpers/contains-test.js
@@ -59,4 +59,17 @@ module('Integration | Helper | {{contains}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'true', 'should render true');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{~#each (contains 1 array) as |val|~}}
+        {{val}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/drop-test.js
+++ b/tests/integration/helpers/drop-test.js
@@ -34,4 +34,17 @@ module('Integration | Helper | {{drop}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '2345', '0 and 1 are dropped');
   });
+
+  test('It allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (drop 2 array) as |n|}}
+        {{n}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/filter-test.js
+++ b/tests/integration/helpers/filter-test.js
@@ -76,4 +76,17 @@ module('Integration | Helper | {{filter}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'ac', 'b is filtered out');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (filter 'name' array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/find-by-test.js
+++ b/tests/integration/helpers/find-by-test.js
@@ -107,4 +107,17 @@ module('Integration | Helper | {{find-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'b', 'b is shown');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#with (find-by 'name' 'd' array) as |value|}}
+        {{value}}
+      {{/with}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/has-next-test.js
+++ b/tests/integration/helpers/has-next-test.js
@@ -35,4 +35,12 @@ module('Integration | Helper | {{has-next}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'false', 'false is shown');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`{{has-next 1 array}}`);
+
+    assert.equal(find('*').textContent.trim(), 'false', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/has-previous-test.js
+++ b/tests/integration/helpers/has-previous-test.js
@@ -35,4 +35,12 @@ module('Integration | Helper | {{has-previous}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'true', 'false is shown');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`{{has-previous 1 array}}`);
+
+    assert.equal(find('*').textContent.trim(), 'false', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/intersect-test.js
+++ b/tests/integration/helpers/intersect-test.js
@@ -38,4 +38,17 @@ module('Integration | Helper | {{intersect}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'foobar', 'bar is added');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (intersect array array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/join-test.js
+++ b/tests/integration/helpers/join-test.js
@@ -34,4 +34,15 @@ module('Integration | Helper | {{join}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'foo, bar, baz, quux', 'quux was added');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{join ', ' array}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/map-test.js
+++ b/tests/integration/helpers/map-test.js
@@ -58,4 +58,20 @@ module('Integration | Helper | {{map}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'abcd', 'd is added');
   });
+
+  test('it allows null array', async function (assert) {
+    this.actions.getName = function({ name }) {
+      return name;
+    };
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (action "getName") as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/next-test.js
+++ b/tests/integration/helpers/next-test.js
@@ -82,4 +82,15 @@ module('Integration | Helper | {{next}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'Jake', 'the next pet name is shown');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{next 1 array}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/object-at-test.js
+++ b/tests/integration/helpers/object-at-test.js
@@ -47,4 +47,15 @@ module('Integration | Helper | {{object-at}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '', 'nothing is displayed');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{object-at 1 array}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/previous-test.js
+++ b/tests/integration/helpers/previous-test.js
@@ -82,4 +82,17 @@ module('Integration | Helper | {{previous}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'Kirby', 'the previous pet name is shown');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#with (previous 1 array) as |value|}}
+        {{value}}
+      {{/with}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/reject-by-test.js
+++ b/tests/integration/helpers/reject-by-test.js
@@ -134,4 +134,17 @@ module('Integration | Helper | {{reject-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'bc', 'a is filtered out');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (reject-by 'name' array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/reverse-test.js
+++ b/tests/integration/helpers/reverse-test.js
@@ -69,4 +69,17 @@ module('Integration | Helper | {{reverse}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'bazfoo', 'array is reversed');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (reverse array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/shuffle-test.js
+++ b/tests/integration/helpers/shuffle-test.js
@@ -105,4 +105,17 @@ module('Integration | Helper | {{shuffle}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '2541', 'array is shuffled');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (shuffle array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/slice-test.js
+++ b/tests/integration/helpers/slice-test.js
@@ -32,4 +32,17 @@ module('Integration | Helper | {{slice}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '4,5', 'sliced values');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (slice 1 2 array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -92,4 +92,17 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (sort-by 'name' array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/union-test.js
+++ b/tests/integration/helpers/union-test.js
@@ -37,4 +37,17 @@ module('Integration | Helper | {{union}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'foobarleetbazqux', 'leet is added');
   });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (union array array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });

--- a/tests/integration/helpers/without-test.js
+++ b/tests/integration/helpers/without-test.js
@@ -100,5 +100,17 @@ module('Integration | Helper | {{without}}', function(hooks) {
 
     assert.equal(this.element.textContent.trim(), 'Eva', 'the remaining pet name is shown');
   });
-});
 
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (without 1 array) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
+});


### PR DESCRIPTION
Array helpers need to be able to take a null array because sometimes
computed promises or other values are unset initially. This adds tests
for all the array helpers and fixes those that did not handle null
correctly.

Some of these were broken by #323, but I didn't check each one.

