### PR TITLE
allow 2 args {{slice}}

### DIFF
--- a/addon/helpers/slice.js
+++ b/addon/helpers/slice.js
@@ -1,10 +1,12 @@
 import { helper } from '@ember/component/helper';
 
-export function slice([start, end, array]) {
+export function slice([...args]) {
+  let array = args.pop();
+
   if (!array) {
     array = [];
   }
-  return array.slice(start, end);
+  return array.slice(...args);
 }
 
 export default helper(slice);

--- a/tests/integration/helpers/slice-test.js
+++ b/tests/integration/helpers/slice-test.js
@@ -18,6 +18,16 @@ module('Integration | Helper | {{slice}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), '4,6', 'sliced values');
   });
 
+  test('It slices when only 2 params are passed', async function(assert) {
+    this.set('array', emberArray([2, 4, 6]));
+
+    await render(hbs`
+      {{slice 1 array}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '4,6', 'sliced values');
+  });
+
   test('It recomputes the slice if an item in the array changes', async function(assert) {
     let array = emberArray([2, 4, 6]);
     this.set('array', array);


### PR DESCRIPTION
## Changes proposed in this pull request

Adds support for 2-argument slice call: `{{slice 1 array}}`.

I saw #259, but it seems it was abandoned, so I created new PR.