### PR TITLE
PoC mut-then and execute

### DIFF
--- a/addon/helpers/execute.js
+++ b/addon/helpers/execute.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import isPromise from '../utils/is-promise';
 
-export function mutThen(actions = []) {
-  return function(...args) {
+export function execute(actions = []) {
+  return function() {
     let invoke = function(acc, curr) {
       if (isPromise(acc)) {
         return acc.then(curr);
@@ -13,7 +13,7 @@ export function mutThen(actions = []) {
 
     return actions.reduce((acc, curr, idx) => {
       if (idx === 0) {
-        return curr(...args);
+        return curr();
       }
 
       return invoke(acc, curr);
@@ -21,4 +21,6 @@ export function mutThen(actions = []) {
   };
 }
 
-export default helper(mutThen);
+export default helper(execute);
+
+

--- a/addon/helpers/mut-then.js
+++ b/addon/helpers/mut-then.js
@@ -1,0 +1,24 @@
+import { helper } from '@ember/component/helper';
+import isPromise from '../utils/is-promise';
+
+export function mutThen(actions = []) {
+  return function(...args) {
+    let invoke = function(acc, curr) {
+      if (isPromise(acc)) {
+        return acc.then(() => curr());
+      }
+
+      return curr();
+    };
+
+    return actions.reduce((acc, curr, idx) => {
+      if (idx === 0) {
+        return curr(...args);
+      }
+
+      return invoke(acc, curr);
+    }, undefined);
+  };
+}
+
+export default helper(mutThen);

--- a/app/helpers/execute.js
+++ b/app/helpers/execute.js
@@ -1,0 +1,1 @@
+export { default, execute } from 'ember-composable-helpers/helpers/execute';

--- a/app/helpers/mut-then.js
+++ b/app/helpers/mut-then.js
@@ -1,0 +1,1 @@
+export { default, mutThen } from 'ember-composable-helpers/helpers/mut-then';

--- a/tests/integration/helpers/execute-test.js
+++ b/tests/integration/helpers/execute-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | execute', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{execute inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});

--- a/tests/integration/helpers/mut-then-test.js
+++ b/tests/integration/helpers/mut-then-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | mut-then', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{mut-then inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});


### PR DESCRIPTION
## Changes proposed in this pull request
There are two helpers in this PR that cover two of our heavy use cases that we couldn't think of any combination of the current existing helpers could solve.

### mut-then Helper

In Ember `{{mut}}` helper is widely used, there's currently no helper to react to some mutation 

While `pipe` works great for processing functions and passing the return value to the next one, in some situations regarding mut, we don't care about about the actual changed value, but we do care about the "event" of something actually changing, like an observer

For example think about an autosave use case, we actually don't care at all about the return value of mut, which also is just undefined I think.
 
```hbs
<PaperInput @onChange={{pipe (fn (mut this.value)) (invoke "save" @model)}} />
```

While `queue` works great for passing the same argument to all the functions, again, in some use cases we just want to react. Using queue is worse because the onChange will be triggered with "my string" and "my string".save doesn't exist, so this is actually a bug.

```hbs
<PaperInput @onChange={{queue (fn (mut this.value)) (invoke "save" @model)}} />
```

I know we can hand write actions in our components to handle stuff like this, but the dev ergonomics and composability goes to the floor.

The mut-then (we can name it differently, honestly is just a PoC) proposal is the first function will receive arguments, and then keep executing the next ones without any args, so we can mutate and then harness the power of partial application without polluting the args.
 
```hbs
<PaperInput @onChange={{mut-then (fn (mut this.value)) (invoke "save" @model)}} />
```

```hbs
<PaperInput @onChange={{mut-then (fn (mut this.value)) (fn (pipe (invoke "save") onModelSaved) @model) }} />
```
And so on... 

### Execute Helper

Literally just execute all the actions without passing anything to them, let partial application do the magic, this is great for reacting to events like `onBlur`, for example we don't really wanna be saving `onChange` for an input, we probably wanna do it onBlur.

```hbs
<PaperInput @onBlur={{(execute (invoke "save" @model) onModelSaved}} />
```
