### PR TITLE
Pick Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Watch a free video overview presented by EmberMap:
       - [`previous`](#previous)
       - [`has-previous`](#has-previous)
     - [Object helpers](#object-helpers)
-      - [`group-by`](#group-by)
-      - [`keys`](#keys)
-      - [`values`](#values)
       - [`entries`](#entries)
       - [`from-entries`](#from-entries)
+      - [`group-by`](#group-by)
+      - [`keys`](#keys)
       - [`pick`](#pick)
+      - [`values`](#values)
     - [Math helpers](#math-helpers)
       - [`inc`](#inc)
       - [`dec`](#dec)
@@ -670,54 +670,6 @@ parameter, `useDeepEqual`, to flag whether a deep equal comparison should be per
 
 ### Object helpers
 
-#### `group-by`
-Returns an object where the keys are the unique values of the given property, and the values are an array with all items of the array that have the same value of that property.
-
-```hbs
-{{#each-in (group-by "category" artists) as |category artists|}}
-  <h3>{{category}}</h3>
-  <ul>
-    {{#each artists as |artist|}}
-      <li>{{artist.name}}</li>
-    {{/each}}
-  </ul>
-{{/each-in}}
-```
-
-**[⬆️ back to top](#table-of-contents)**
-
-#### `keys`
-Returns an array of keys of given object.
-
-```hbs
-{{#with (keys fields) as |labels|}}
-  <h3>This article contain {{labels.length}} fields</h3>
-  <ul>
-    {{#each labels as |label|}}
-      <li>{{label}}</li>
-    {{/each}}
-  </ul>
-{{/with}}
-```
-
-**[⬆️ back to top](#table-of-contents)**
-
-#### `values`
-Returns an array of values from the given object.
-
-```hbs
-{{#with (values fields) as |data|}}
-  <h3>This article contain {{data.length}} fields</h3>
-  <ul>
-    {{#each data as |datum|}}
-      <li>{{datum}}</li>
-    {{/each}}
-  </ul>
-{{/with}}
-```
-
-**[⬆️ back to top](#table-of-contents)**
-
 #### `entries`
 Returns an array of a given object's own enumerable string-keyed property `[key, value]` pairs
 
@@ -757,6 +709,38 @@ properties with non-falsey values:
 
 **[⬆️ back to top](#table-of-contents)**
 
+#### `group-by`
+Returns an object where the keys are the unique values of the given property, and the values are an array with all items of the array that have the same value of that property.
+
+```hbs
+{{#each-in (group-by "category" artists) as |category artists|}}
+  <h3>{{category}}</h3>
+  <ul>
+    {{#each artists as |artist|}}
+      <li>{{artist.name}}</li>
+    {{/each}}
+  </ul>
+{{/each-in}}
+```
+
+**[⬆️ back to top](#table-of-contents)**
+
+#### `keys`
+Returns an array of keys of given object.
+
+```hbs
+{{#with (keys fields) as |labels|}}
+  <h3>This article contain {{labels.length}} fields</h3>
+  <ul>
+    {{#each labels as |label|}}
+      <li>{{label}}</li>
+    {{/each}}
+  </ul>
+{{/with}}
+```
+
+**[⬆️ back to top](#table-of-contents)**
+
 #### `pick`
 Receives an object and picks a specified path off of it to pass on. Intended for use with `{{on}}` modifiers placed on form elements.
 
@@ -774,6 +758,22 @@ It also supports an optional second argument to make common usage more ergonomic
     ...
     {{on 'input' (pick 'target.value' this.onInput)}}
   />
+```
+
+**[⬆️ back to top](#table-of-contents)*
+
+#### `values`
+Returns an array of values from the given object.
+
+```hbs
+{{#with (values fields) as |data|}}
+  <h3>This article contain {{data.length}} fields</h3>
+  <ul>
+    {{#each data as |datum|}}
+      <li>{{datum}}</li>
+    {{/each}}
+  </ul>
+{{/with}}
 ```
 
 **[⬆️ back to top](#table-of-contents)*

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Watch a free video overview presented by EmberMap:
       - [`values`](#values)
       - [`entries`](#entries)
       - [`from-entries`](#from-entries)
+      - [`pick`](#pick)
     - [Math helpers](#math-helpers)
       - [`inc`](#inc)
       - [`dec`](#dec)
@@ -755,6 +756,27 @@ properties with non-falsey values:
 ```
 
 **[⬆️ back to top](#table-of-contents)**
+
+#### `pick`
+Receives an object and picks a specified path off of it to pass on. Intended for use with `{{on}}` modifiers placed on form elements.
+
+```hbs
+  <input
+    ...
+    {{on 'input' (pipe (pick 'target.value') this.onInput)}}
+  />
+```
+
+It also supports an optional second argument to make common usage more ergonomic.
+
+```hbs
+  <input
+    ...
+    {{on 'input' (pick 'target.value' this.onInput)}}
+  />
+```
+
+**[⬆️ back to top](#table-of-contents)*
 
 ---
 

--- a/addon/helpers/pick.js
+++ b/addon/helpers/pick.js
@@ -1,0 +1,14 @@
+import { helper } from '@ember/component/helper';
+import { get } from '@ember/object';
+
+export default helper(function event([path, action]/*, hash*/) {
+  return function(event) {
+    let value = get(event, path);
+
+    if (!action) {
+      return value;
+    }
+
+    action(value);
+  };
+});

--- a/app/helpers/pick.js
+++ b/app/helpers/pick.js
@@ -1,0 +1,1 @@
+export { default, pick } from 'ember-composable-helpers/helpers/pick';

--- a/tests/integration/helpers/pick-test.js
+++ b/tests/integration/helpers/pick-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | pick', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test("Works when used with {{on}} modifier and pipe", async function(assert) {
+    assert.expect(1);
+
+    this.set('onFocus', function(value) {
+      assert.equal(value, 'pizza party', 'The action receives the correct value');
+    })
+
+    await render(hbs`
+      <input
+        id="test-input"
+        value="pizza party"
+        {{on 'focusin' (pipe (pick 'target.value') this.onFocus)}}
+      />
+    `);
+
+    await click('#test-input');
+  });
+
+  test("Shorthand works when used with {{on}} modifier and optional action is provided", async function(assert) {
+    assert.expect(1);
+
+    this.set('onFocus', function(value) {
+      assert.equal(value, 'pizza party', 'The action receives the correct value');
+    })
+
+    await render(hbs`
+      <input
+        id="test-input"
+        value="pizza party"
+        {{on 'focusin' (pick 'target.value' this.onFocus)}}
+      />
+    `);
+
+    await click('#test-input');
+  });
+});


### PR DESCRIPTION
Hello! Long time listener, first time caller....

## Changes proposed in this pull request
This PR introduces a `pick` helper. When using the {{on}} modifier, I've found myself writing a lot of component actions that grab a particular value off of the emitted event to pass along. This helper makes it easy to pick off a particular value and either return it or send it to an optional action. 

I was considering creating an addon for this, but it fits well within the composable helpers domain, so I figured I'd propose it here first. 

I'm open to suggestions on improvements
