### PR TITLE
Fix sort-by to accept Ember Data relationship

### DIFF
--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -24,6 +24,9 @@ function sortAsc(key, a, b) {
 class SortBy {
   constructor(...args) {
     let [array] = args;
+    if (typeof array.toArray === "function") {
+      array = array.toArray();
+    }
 
     this.array = [...array];
     this.callbacks = null;

--- a/tests/integration/helpers/filter-test.js
+++ b/tests/integration/helpers/filter-test.js
@@ -89,4 +89,29 @@ module('Integration | Helper | {{filter}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
   });
+
+  test('it accepts a fulfilled ember data promise as a value', async function (assert) {
+    let store = this.owner.lookup('service:store');
+    let person = store.createRecord('person');
+
+    person.get('pets').pushObjects([
+      store.createRecord('pet', { name: 'aa' }),
+      store.createRecord('pet', { name: 'ab' }),
+      store.createRecord('pet', { name: 'bc' }),
+    ]);
+    let pets = await person.pets;
+    this.set('pets', pets);
+
+    this.actions.startsWithA = function({ name }) {
+      return name.startsWith('a');
+    };
+
+    await render(hbs`
+      {{~#each (filter (action "startsWithA") pets) as |item|~}}
+        {{~item.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'aaab', 'bc is filtered out');
+  });
 });

--- a/tests/integration/helpers/map-by-test.js
+++ b/tests/integration/helpers/map-by-test.js
@@ -92,4 +92,26 @@ module('Integration | Helper | {{map-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '', 'this is all that will render, but there is no error');
   });
+
+  test('it accepts a fulfilled ember data promise as a value', async function (assert) {
+    let store = this.owner.lookup('service:store');
+    let person = store.createRecord('person');
+
+    person.get('pets').pushObjects([
+      store.createRecord('pet', { name: 'a' }),
+      store.createRecord('pet', { name: 'b' }),
+      store.createRecord('pet', { name: 'c' }),
+    ]);
+    let pets = await person.pets;
+
+    this.set('pets', pets);
+
+    await render(hbs`
+      {{~#each (map-by 'name' pets) as |name|~}}
+        {{~name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'abc', 'name property is mapped');
+  });
 });

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -137,4 +137,26 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
   });
+
+  test('it accepts a fulfilled ember data promise as a value', async function (assert) {
+    let store = this.owner.lookup('service:store');
+    let person = store.createRecord('person');
+
+    person.get('pets').pushObjects([
+      store.createRecord('pet', { name: 'c' }),
+      store.createRecord('pet', { name: 'b' }),
+      store.createRecord('pet', { name: 'a' }),
+    ]);
+    let pets = await person.pets;
+
+    this.set('pets', pets);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' pets) as |pet|~}}
+        {{~pet.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
+  });
 });


### PR DESCRIPTION
The refactor of `sort-by` in #362 by @snewcomer no longer accepts a resolved Ember Data hasMany relationship as [this line](https://github.com/DockYard/ember-composable-helpers/blob/master/addon/helpers/sort-by.js#L28) throws `array is not iterable`.