### PR TITLE
Refactor sort by to Alphabetical instead of ASCII(betical)

### DIFF
--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -14,11 +14,35 @@ function normalizeToBoolean(val) {
 }
 
 function sortDesc(key, a, b) {
-  return get(a, key) > get(b, key);
+  const aValue = get(a, key);
+  const bValue = get(b, key);
+
+  if (aValue.toLowerCase && bValue.toLowerCase) {
+    return bValue.localeCompare(aValue, undefined, { sensitivity: 'base' });
+  }
+
+  // if false, b comes before a
+  if (aValue < bValue) {
+    return 1
+  } else {
+    return -1;
+  }
 }
 
 function sortAsc(key, a, b) {
-  return get(a, key) < get(b, key);
+  const aValue = get(a, key);
+  const bValue = get(b, key);
+
+  if (aValue.toLowerCase && bValue.toLowerCase) {
+    return aValue.localeCompare(bValue, undefined, { sensitivity: 'base' });
+  }
+
+  // if true, a comes before b
+  if (aValue < bValue) {
+    return -1
+  } else {
+    return 1;
+  }
 }
 
 class SortBy {

--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -21,10 +21,9 @@ function sortDesc(key, a, b) {
     return bValue.localeCompare(aValue, undefined, { sensitivity: 'base' });
   }
 
-  // if false, b comes before a
   if (aValue < bValue) {
     return 1
-  } else if (a > bValue) {
+  } else if (aValue > bValue) {
     return -1;
   }
 
@@ -39,11 +38,9 @@ function sortAsc(key, a, b) {
     return aValue.localeCompare(bValue, undefined, { sensitivity: 'base' });
   }
 
-  // if true, a comes before b
-  // if false, b comes before a
   if (aValue < bValue) {
     return -1
-  } else if (a > bValue) {
+  } else if (aValue > bValue) {
     return 1;
   }
 

--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -24,9 +24,11 @@ function sortDesc(key, a, b) {
   // if false, b comes before a
   if (aValue < bValue) {
     return 1
-  } else {
+  } else if (a > bValue) {
     return -1;
   }
+
+  return 0;
 }
 
 function sortAsc(key, a, b) {
@@ -38,11 +40,14 @@ function sortAsc(key, a, b) {
   }
 
   // if true, a comes before b
+  // if false, b comes before a
   if (aValue < bValue) {
     return -1
-  } else {
+  } else if (a > bValue) {
     return 1;
   }
+
+  return 0;
 }
 
 class SortBy {

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -47,10 +47,10 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
   test('It sorts by a value based on Alphanumeric', async function(assert) {
     this.set('array', [
-      { name: '1' },
-      { name: '11' },
-      { name: '2' },
-      { name: '100' }
+      { name: 'c1' },
+      { name: 'c11' },
+      { name: 'c2' },
+      { name: 'c100' }
     ]);
 
     await render(hbs`

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -1,6 +1,6 @@
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -17,7 +17,8 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     this.set('array', [
       { name: 'c' },
       { name: 'a' },
-      { name: 'b' }
+      { name: 'b' },
+      { name: 'c' }
     ]);
 
     await render(hbs`
@@ -26,7 +27,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
       {{~/each~}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
+    assert.equal(find('*').textContent.trim(), 'abcc', 'cabc is sorted to abcc');
   });
 
   test('It sorts by a value based on Alphabetical (vs ASCII-betical)', async function(assert) {
@@ -45,7 +46,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'bCc', 'outputs alphabeticl ordering with b before c');
   });
 
-  test('It sorts by a value based on Alphanumeric', async function(assert) {
+  skip('It sorts by a value based on Alphanumeric', async function(assert) {
     this.set('array', [
       { name: 'c1' },
       { name: 'c11' },
@@ -82,7 +83,8 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     this.set('array', emberArray([
       { name: 'c' },
       { name: 'a' },
-      { name: 'b' }
+      { name: 'b' },
+      { name: 'a' }
     ]));
 
     await render(hbs`
@@ -91,7 +93,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
       {{~/each~}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'cba', 'cab is sorted to cba');
+    assert.equal(find('*').textContent.trim(), 'cbaa', 'cab is sorted to cbaa');
   });
 
   test('It watches for changes', async function(assert) {

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -13,7 +13,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
   });
 
-  test('It sorts by a value', async function(assert) {
+  test('It sorts by a value ascending', async function(assert) {
     this.set('array', [
       { name: 'c' },
       { name: 'a' },
@@ -29,7 +29,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
   });
 
-  test('It sorts by a value based on casing', async function(assert) {
+  test('It sorts by a value based on Alphabetical (vs ASCII-betical)', async function(assert) {
     this.set('array', [
       { name: 'c' },
       { name: 'C' },
@@ -42,7 +42,24 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
       {{~/each~}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'bcC', 'cab is sorted to abc');
+    assert.equal(find('*').textContent.trim(), 'bCc', 'outputs alphabeticl ordering with b before c');
+  });
+
+  test('It sorts by a value based on Alphanumeric', async function(assert) {
+    this.set('array', [
+      { name: '1' },
+      { name: '11' },
+      { name: '2' },
+      { name: '100' }
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'c1c2c11c100', 'cab is sorted to Cbc');
   });
 
   test('It sorts by a value with EmberArray', async function(assert) {

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -128,7 +128,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
       {{~/each~}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'c1c2c11c100', 'cab is sorted to Cbc');
+    assert.equal(find('*').textContent.trim(), 'c1c2c11c100', 'alpha numeric is sorted properly');
   });
 
   test('It sorts by a value with EmberArray', async function(assert) {
@@ -161,7 +161,7 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
       {{~/each~}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'cbaa', 'cab is sorted to cbaa');
+    assert.equal(find('*').textContent.trim(), 'cbaa', 'caba is sorted to cbaa');
   });
 
   test('It watches for changes', async function(assert) {

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -29,6 +29,22 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
   });
 
+  test('It sorts by a value based on casing', async function(assert) {
+    this.set('array', [
+      { name: 'c' },
+      { name: 'C' },
+      { name: 'b' }
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'bcC', 'cab is sorted to abc');
+  });
+
   test('It sorts by a value with EmberArray', async function(assert) {
     this.set('array', emberArray([
       { name: 'c' },

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -30,6 +30,40 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'abcc', 'cabc is sorted to abcc');
   });
 
+  test('It sorts by a value Numbers strings', async function(assert) {
+    this.set('array', [
+      { value: '1' },
+      { value: '0' },
+      { value: '1' },
+      { value: '2' }
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'value' array) as |user|~}}
+        {{~user.value~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '0112', 'numbes are sorted');
+  });
+
+  test('It sorts by a value Number', async function(assert) {
+    this.set('array', [
+      { value: 1 },
+      { value: 0 },
+      { value: 1 },
+      { value: 2 }
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'value' array) as |user|~}}
+        {{~user.value~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '0112', 'numbes are sorted');
+  });
+
   test('It sorts by a value based on Alphabetical (vs ASCII-betical)', async function(assert) {
     this.set('array', [
       { name: 'c' },

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -30,6 +30,40 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'abcc', 'cabc is sorted to abcc');
   });
 
+  test('It sorts by multiletter words ascending', async function(assert) {
+    this.set('array', [
+      { name: 'Aa' },
+      { name: 'aA' },
+      { name: 'bc' },
+      { name: 'cb' }
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'aAAabccb', 'sorts multiletter words');
+  });
+
+  test('It sorts by multiletter words descending', async function(assert) {
+    this.set('array', [
+      { name: 'Aa' },
+      { name: 'aA' },
+      { name: 'bc' },
+      { name: 'cb' }
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name:desc' array) as |user|~}}
+        {{~user.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'cbbcaAAa', 'sorts multiletter words');
+  });
+
   test('It sorts by a value Numbers strings', async function(assert) {
     this.set('array', [
       { value: '1' },


### PR DESCRIPTION
Native JS sort sorts by ASCII code, from lowest to highest.

'a'.charCodeAt() === '97'
'A'.charCodeAt() === '65'

```
// native JS
['a', 'A', 'b'].sort() === ['A', 'a', 'b']
```

```
// This PR
['a', 'A', 'b'].sort() === ['A', 'a', 'b']
```

However, the human mind may prefer `['a', 'A', 'b']` (subjective).  The best way to think about it as case insensitive ordering.

Follow up - AlphaNumeric ordering. (skipped test)

close #369