### PR TITLE
Ignore undefined values when sorting

### DIFF
--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -17,7 +17,7 @@ function sortDesc(key, a, b) {
   const aValue = get(a, key);
   const bValue = get(b, key);
 
-  if (aValue.toLowerCase && bValue.toLowerCase) {
+  if (aValue && bValue && aValue.toLowerCase && bValue.toLowerCase) {
     return bValue.localeCompare(aValue, undefined, { sensitivity: 'base' });
   }
 
@@ -34,7 +34,7 @@ function sortAsc(key, a, b) {
   const aValue = get(a, key);
   const bValue = get(b, key);
 
-  if (aValue.toLowerCase && bValue.toLowerCase) {
+  if (aValue && bValue && aValue.toLowerCase && bValue.toLowerCase) {
     return aValue.localeCompare(bValue, undefined, { sensitivity: 'base' });
   }
 

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -262,4 +262,21 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
   });
+
+  test('ignores undefined values sorting', async function (assert) {
+    this.set('array', [
+      { name: 'c' },
+      { name: 'a' },
+      { name: undefined },
+      { name: 'b' },
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |pet|~}}
+        {{~pet.name~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'abc');
+  });
 });


### PR DESCRIPTION
Before #370 `undefined` values could be sorted, now they can again.