### PR TITLE
Add failing test for consistent order when values are the same

### DIFF
--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -317,4 +317,20 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'abc');
   });
+
+  test('It maintains order when values are the same', async function(assert) {
+    this.set('array', [
+      { id: 1, name: 'a' },
+      { id: 2, name: 'a' },
+      { id: 3, name: 'a' },
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.id~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '123');
+  });
 });


### PR DESCRIPTION
Another edge case for the `sort-by` helper. When values are the same the order is currently reversed. In 4.0 it would remain the same and I believe that is the correct behavior.
