### PR TITLE
Fix sort-by with null values

### DIFF
--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -21,11 +21,11 @@ function sortDesc(key, a, b) {
   const aValue = get(a, key);
   const bValue = get(b, key);
 
-  if (typeof bValue == 'undefined') {
+  if (typeof bValue == 'undefined' || bValue === null) {
     // keep bValue last
     return -1;
   }
-  if (typeof aValue == 'undefined') {
+  if (typeof aValue == 'undefined' || aValue === null) {
     // put aValue last
     return 1;
   }
@@ -47,11 +47,11 @@ function sortAsc(key, a, b) {
   const aValue = get(a, key);
   const bValue = get(b, key);
 
-  if (typeof bValue == 'undefined') {
+  if (typeof bValue == 'undefined' || bValue === null) {
     // keep bValue last
     return -1;
   }
-  if (typeof aValue == 'undefined') {
+  if (typeof aValue == 'undefined' || aValue === null) {
     // put aValue last
     return 1;
   }

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -301,21 +301,21 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'abc', 'cab is sorted to abc');
   });
 
-  test('ignores undefined values sorting', async function (assert) {
+  test('it sorts undefined values last', async function(assert) {
     this.set('array', [
-      { name: 'c' },
-      { name: 'a' },
-      { name: undefined },
-      { name: 'b' },
+      { id: 1, name: 'c' },
+      { id: 2, name: 'a' },
+      { id: 3, name: undefined },
+      { id: 4, name: 'b' },
     ]);
 
     await render(hbs`
-      {{~#each (sort-by 'name' array) as |pet|~}}
-        {{~pet.name~}}
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.id~}}
       {{~/each~}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'abc');
+    assert.equal(find('*').textContent.trim(), '2413');
   });
 
   test('it sorts null values last', async function(assert) {

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -318,6 +318,23 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
     assert.equal(find('*').textContent.trim(), 'abc');
   });
 
+  test('it sorts null values last', async function(assert) {
+    this.set('array', [
+      { id: 1, name: 'c' },
+      { id: 2, name: 'a' },
+      { id: 3, name: null },
+      { id: 4, name: 'b' },
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.id~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '2413');
+  });
+
   test('It maintains order when values are the same', async function(assert) {
     this.set('array', [
       { id: 1, name: 'a' },


### PR DESCRIPTION
https://github.com/DockYard/ember-composable-helpers/pull/376/commits/e7a8f01a2d84545924e6919d50ef1c19397b669d breaks `sort-by` when a value is `null` since `null.toLowerCase` throws the following:

```
Uncaught TypeError: Cannot read property 'toLowerCase' of null
```

I suppose the truthy checks were required after all to prevent that

---

I'm not sure what the ideal handling of null values should be, so this PR is just my take:

I believe null values should be sorted last as well since doing comparisons to null can lead to inconsistent sorting:
```js
// Ignored (left in place) when compared to strings
"a" < null // false
"a" > null // false

// Sorted when compared to numbers
1 > null // true
1 < null // false
```

However, this doesn't sort between `undefined` and `null` -- not sure if that's a problem.

Also made a change to the `'ignores undefined values sorting'` test case since undefined values should be expected to be sorted last now, not ignored. The way the test was written, it would never fail regardless of the position the undefined value was in

