### PR TITLE
Rename {{contains}} helper to {{includes}}

### DIFF
--- a/addon/helpers/contains.js
+++ b/addon/helpers/contains.js
@@ -1,18 +1,18 @@
-import { A as emberArray } from '@ember/array';
-import { isArray as isEmberArray } from '@ember/array';
 import { helper } from '@ember/component/helper';
+import { includes } from './includes';
+import { deprecate } from '@ember/debug';
 
 export function contains(needleOrNeedles, haystack) {
-  if (!isEmberArray(haystack)) {
-    return false;
-  }
+  deprecate(
+    '{{contains}} helper provided by ember-composable-helpers has been renamed to {{includes}}.',
+    false,
+    {
+      id: 'ember-composable-helpers.contains-helper',
+      until: '5.0.0'
+    }
+  );
 
-  let needles = isEmberArray(needleOrNeedles) ? needleOrNeedles : [needleOrNeedles];
-  let haystackAsEmberArray = emberArray(haystack);
-
-  return needles.every((needle) => {
-    return haystackAsEmberArray.includes(needle);
-  });
+  return includes(needleOrNeedles, haystack);
 }
 
 export default helper(function([needle, haystack]) {

--- a/addon/helpers/contains.js
+++ b/addon/helpers/contains.js
@@ -1,10 +1,9 @@
 import { A as emberArray } from '@ember/array';
 import { isArray as isEmberArray } from '@ember/array';
 import { helper } from '@ember/component/helper';
-import includes from '../utils/includes';
 
 function _contains(needle, haystack) {
-  return includes(emberArray(haystack), needle);
+  return emberArray(haystack).includes(needle);
 }
 
 export function contains(needle, haystack) {

--- a/addon/helpers/contains.js
+++ b/addon/helpers/contains.js
@@ -2,20 +2,17 @@ import { A as emberArray } from '@ember/array';
 import { isArray as isEmberArray } from '@ember/array';
 import { helper } from '@ember/component/helper';
 
-function _contains(needle, haystack) {
-  return emberArray(haystack).includes(needle);
-}
-
-export function contains(needle, haystack) {
+export function contains(needleOrNeedles, haystack) {
   if (!isEmberArray(haystack)) {
     return false;
   }
 
-  if (isEmberArray(needle)) {
-    return needle.reduce((acc, val) => acc && _contains(val, haystack), true);
-  }
+  let needles = isEmberArray(needleOrNeedles) ? needleOrNeedles : [needleOrNeedles];
+  let haystackAsEmberArray = emberArray(haystack);
 
-  return _contains(needle, haystack);
+  return needles.every((needle) => {
+    return haystackAsEmberArray.includes(needle);
+  });
 }
 
 export default helper(function([needle, haystack]) {

--- a/addon/helpers/includes.js
+++ b/addon/helpers/includes.js
@@ -1,0 +1,20 @@
+import { A as emberArray } from '@ember/array';
+import { isArray as isEmberArray } from '@ember/array';
+import { helper } from '@ember/component/helper';
+
+export function includes(needleOrNeedles, haystack) {
+  if (!isEmberArray(haystack)) {
+    return false;
+  }
+
+  let needles = isEmberArray(needleOrNeedles) ? needleOrNeedles : [needleOrNeedles];
+  let haystackAsEmberArray = emberArray(haystack);
+
+  return needles.every((needle) => {
+    return haystackAsEmberArray.includes(needle);
+  });
+}
+
+export default helper(function([needle, haystack]) {
+  return includes(needle, haystack);
+});

--- a/addon/helpers/without.js
+++ b/addon/helpers/without.js
@@ -1,9 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { A as emberArray, isArray as isEmberArray } from '@ember/array';
-import includes from '../utils/includes';
 
 function contains(needle, haystack) {
-  return includes(emberArray(haystack), needle);
+  return emberArray(haystack).includes(needle);
 }
 
 export function without(needle, haystack) {

--- a/addon/utils/includes.js
+++ b/addon/utils/includes.js
@@ -1,4 +1,0 @@
-export default function includes(haystack, ...args) {
-  let finder = haystack.includes || haystack.contains;
-  return finder.apply(haystack, args);
-}

--- a/app/helpers/includes.js
+++ b/app/helpers/includes.js
@@ -1,0 +1,1 @@
+export { default, includes } from 'ember-composable-helpers/helpers/includes';

--- a/tests/integration/helpers/includes-test.js
+++ b/tests/integration/helpers/includes-test.js
@@ -1,0 +1,75 @@
+import { run } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | {{includes}}', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it checks if an array includes a primitive value', async function(assert) {
+    this.set('items', ['foo', 'bar', 'baz']);
+
+    await render(hbs`{{includes 'foo' items}}`);
+
+    assert.equal(find('*').textContent.trim(), 'true', 'should render true');
+  });
+
+  test('it checks if an array includes a non-primitive value', async function(assert) {
+    let games = [
+      { name: 'Firewatch' },
+      { name: 'Rocket League' },
+      { name: 'CSGO' }
+    ];
+    this.set('selectedGame', games[0]);
+    this.set('wishlist', games);
+
+    await render(hbs`{{includes selectedGame wishlist}}`);
+
+    assert.equal(find('*').textContent.trim(), 'true', 'should render true');
+  });
+
+  test('it checks if an array includes an array of primitive values', async function(assert) {
+    this.set('items', ['foo', 'bar', 'baz', undefined, null]);
+    this.set('selectedItems', ['foo', 'bar', undefined, null]);
+
+    await render(hbs`{{includes selectedItems items}}`);
+
+    assert.equal(find('*').textContent.trim(), 'true', 'should render true');
+  });
+
+  test('it watches for changes', async function(assert) {
+    let games = [
+      { name: 'Firewatch' },
+      { name: 'Rocket League' },
+      { name: 'CSGO' }
+    ];
+    this.set('selectedGame', games[0]);
+    this.set('wishlist', games);
+
+    await render(hbs`{{includes selectedGame wishlist}}`);
+
+    assert.equal(find('*').textContent.trim(), 'true', 'should render true');
+
+    run(() => this.get('wishlist').removeObject(games[0]));
+
+    assert.equal(find('*').textContent.trim(), 'false', 'should render false');
+
+    run(() => this.set('selectedGame', games[1]));
+
+    assert.equal(find('*').textContent.trim(), 'true', 'should render true');
+  });
+
+  test('it allows null array', async function(assert) {
+    this.set('array', null);
+
+    await render(hbs`
+      this is all that will render
+      {{~#each (includes 1 array) as |val|~}}
+        {{val}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
+});


### PR DESCRIPTION
This renamed `{{contains}}` helper to `{{includes}}` as discussed in #365. A deprecation warning is added for the old name.

Additional I have refactored to code:

- Remove code only needed to support Ember versions, which fall back to `EmberArray.contains()` if `EmberArray.includes()` is not available. `EmberArray.contains()` has been removed in 2.x. `EmberArray.includes()` is available in all supported version.
- Avoid converting the array passed in multiple times to `EmberArray` if an array of needles is provided.
- Use `Array.every()` (or `EmberArray.every()`) instead of `Array.reduce()` to improve readability and performance.
- Use same code path for single needle and array of needles to reduce complexity. This may have a bad performance impact as it requires creating an interim array if a single needle is passed. But the performance impact should be small enough to be acceptable.

Closes #365 