### PR TITLE
use `confirmedArrays` when performing intersect

### DIFF
--- a/addon/helpers/intersect.js
+++ b/addon/helpers/intersect.js
@@ -7,9 +7,9 @@ export function intersect([...arrays]) {
   });
   // copied from https://github.com/emberjs/ember.js/blob/315ec6472ff542ac714432036cc96fe4bd62bd1f/packages/%40ember/object/lib/computed/reduce_computed_macros.js#L1063-L1100
   let results = confirmedArrays.pop().filter(candidate => {
-    for (let i = 0; i < arrays.length; i++) {
+    for (let i = 0; i < confirmedArrays.length; i++) {
       let found = false;
-      let array = arrays[i];
+      let array = confirmedArrays[i];
       for (let j = 0; j < array.length; j++) {
         if (array[j] === candidate) {
           found = true;

--- a/tests/integration/helpers/intersect-test.js
+++ b/tests/integration/helpers/intersect-test.js
@@ -51,4 +51,18 @@ module('Integration | Helper | {{intersect}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
   });
+
+  test('it allows a first parameter null array', async function(assert) {
+    this.set('array1', null);
+    this.set('array2', ['foo', 'baz']);
+
+    await render(hbs`
+      this is all that will render
+      {{#each (intersect array1 array2) as |value|}}
+        {{value}}
+      {{/each}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'this is all that will render', 'no error is thrown');
+  });
 });


### PR DESCRIPTION
I am attempting to upgrade from `ember-composable-helpers` from 2.x.x to 4.x.x  and I am seeing an issue when using `intersect` with 2 parameters, the first initially being `null` due to a promise.

The stack trace thrown was:
```
TypeError: Cannot read property 'length' of null
    at http://localhost:7357/assets/vendor.js:90243:35
    at Array.filter (<anonymous>)
    at intersect (http://localhost:7357/assets/vendor.js:90238:41)
    at http://localhost:7357/assets/vendor.js:5829:29
    at deprecateMutationsInAutotrackingTransaction (http://localhost:7357/assets/vendor.js:55142:9)
    at EmberHelperRootReference.fnWrapper [as fn] (http://localhost:7357/assets/vendor.js:5828:70)
    at http://localhost:7357/assets/vendor.js:47086:34
    at runInAutotrackingTransaction (http://localhost:7357/assets/vendor.js:55114:9)
    at track (http://localhost:7357/assets/vendor.js:55626:9)
    at EmberHelperRootReference.compute (http://localhost:7357/assets/vendor.js:47085:46)
```

It appears to be due to the fact that the work of the intersect is based on the `arrays` parameter instead of the cleaned up `confirmedArrays` [here](https://github.com/DockYard/ember-composable-helpers/blob/5754b4195581394efa261ac22ad3d269d70f62f5/addon/helpers/intersect.js#L10) and [here](https://github.com/DockYard/ember-composable-helpers/blob/5754b4195581394efa261ac22ad3d269d70f62f5/addon/helpers/intersect.js#L13) .  `confirmedArrays` was added in this PR: https://github.com/DockYard/ember-composable-helpers/pull/336 and I believe should have been used in place of `arrays` the entire intersect helper. 

The existing null test didn't catch it because both parameters were null and thus the `.filter` no-oped and did not execute the major work of the intersect. 

## Changes proposed in this pull request

Use `confirmedArrays` as opposed to `arrays` in the entire `intersect` helper. This is also in line with the linked implementation here: https://github.com/emberjs/ember.js/blob/315ec6472ff542ac714432036cc96fe4bd62bd1f/packages/%40ember/object/lib/computed/reduce_computed_macros.js#L1063-L1100
