### PR TITLE
[sort-by] Cannot call get with [keyName] on an undefined object.

### DIFF
--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -18,13 +18,20 @@ function normalizeToBoolean(val) {
   return val;
 }
 
+function safeValueForKey(ctx, key) {
+  if (ctx === null || ctx === undefined) {
+    return ctx;
+  }
+  return get(ctx, key);
+}
+
 function sortDesc(key, a, b) {
   if (isEmpty(key)) {
     return 0;
   }
 
-  const aValue = get(a, key);
-  const bValue = get(b, key);
+  const aValue = safeValueForKey(a, key);
+  const bValue = safeValueForKey(b, key);
 
   if (typeof bValue == 'undefined' || bValue === null) {
     // keep bValue last
@@ -53,8 +60,8 @@ function sortAsc(key, a, b) {
     return 0;
   }
 
-  const aValue = get(a, key);
-  const bValue = get(b, key);
+  const aValue = safeValueForKey(a, key);
+  const bValue = safeValueForKey(b, key);
 
   if (typeof bValue == 'undefined' || bValue === null) {
     // keep bValue last

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -366,4 +366,38 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '123');
   });
+
+  test('it support undefined array values', async function(assert) {
+    this.set('array', [
+      { id: 1, name: 'c' },
+      { id: 2, name: 'a' },
+      undefined,
+      { id: 4, name: 'b' },
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.id~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '241');
+  });
+
+  test('it support null array values', async function(assert) {
+    this.set('array', [
+      { id: 1, name: 'c' },
+      { id: 2, name: 'a' },
+      null,
+      { id: 4, name: 'b' },
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'name' array) as |user|~}}
+        {{~user.id~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '241');
+  });
 });


### PR DESCRIPTION
Closes #387

added check for null or undefined, before ember's get usage to prevent mentioned errors