### PR TITLE
fixes sort-by case with multiple properties and nulls

### DIFF
--- a/addon/helpers/sort-by.js
+++ b/addon/helpers/sort-by.js
@@ -34,11 +34,19 @@ function sortDesc(key, a, b) {
   const aValue = safeValueForKey(a, key);
   const bValue = safeValueForKey(b, key);
 
-  if (typeof bValue == 'undefined' || bValue === null) {
+  const isANullable = typeof aValue == 'undefined' || aValue === null;
+  const isBNullable = typeof bValue == 'undefined' || bValue === null;
+
+  if (isANullable && isBNullable) {
+    //both values are nullable
+    return 0;
+  }
+
+  if (isBNullable) {
     // keep bValue last
     return -1;
   }
-  if (typeof aValue == 'undefined' || aValue === null) {
+  if (isANullable) {
     // put aValue last
     return 1;
   }
@@ -64,11 +72,19 @@ function sortAsc(key, a, b) {
   const aValue = safeValueForKey(a, key);
   const bValue = safeValueForKey(b, key);
 
-  if (typeof bValue == 'undefined' || bValue === null) {
+  const isANullable = typeof aValue == 'undefined' || aValue === null;
+  const isBNullable = typeof bValue == 'undefined' || bValue === null;
+
+  if (isANullable && isBNullable) {
+    //both values are nullable
+    return 0;
+  }
+
+  if (isBNullable) {
     // keep bValue last
     return -1;
   }
-  if (typeof aValue == 'undefined' || aValue === null) {
+  if (isANullable) {
     // put aValue last
     return 1;
   }

--- a/tests/integration/helpers/sort-by-test.js
+++ b/tests/integration/helpers/sort-by-test.js
@@ -400,4 +400,34 @@ module('Integration | Helper | {{sort-by}}', function(hooks) {
 
     assert.equal(find('*').textContent.trim(), '241');
   });
+
+  test('it sorts asc by a few params some of those are all null', async function(assert) {
+    this.set('array', [
+      { creationDate: null, attrs: { trialNumber: '00-01'}, localOrder: 1 },
+      { creationDate: null, attrs: { trialNumber: '00-02'}, localOrder: 2 },      
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'creationDate:asc' 'attrs.trialNumber:asc' 'localOrder' array) as |trial|~}}
+        {{~trial.attrs.trialNumber~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '00-0100-02');
+  })
+
+  test('it sorts desc by a few params some of those are all null', async function(assert) {
+    this.set('array', [      
+      { creationDate: null, attrs: { trialNumber: '00-02'}, localOrder: 1 },
+      { creationDate: null, attrs: { trialNumber: '00-01'}, localOrder: 2 },
+    ]);
+
+    await render(hbs`
+      {{~#each (sort-by 'creationDate:desc' 'attrs.trialNumber:desc' 'localOrder' array) as |trial|~}}
+        {{~trial.attrs.trialNumber~}}
+      {{~/each~}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), '00-0200-01');
+  })
 });


### PR DESCRIPTION
Fixed case where some sorting values are null and other sorting keys doesn't applied