### PR TITLE
Embroider Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
             ember-beta,
             ember-canary,
             ember-default-with-jquery,
-            embroider-tests,
+            embroider-safe,
+            embroider-optimized
           ]
     continue-on-error: ${{ matrix.try-scenario == 'ember-beta' || matrix.try-scenario == 'ember-canary' }}
     steps:

--- a/app/helpers/entries.js
+++ b/app/helpers/entries.js
@@ -1,1 +1,4 @@
-export { default, entries } from 'ember-composable-helpers/helpers/entries';
+export {
+  default,
+  keys as entries,
+} from 'ember-composable-helpers/helpers/entries';

--- a/app/helpers/from-entries.js
+++ b/app/helpers/from-entries.js
@@ -1,1 +1,1 @@
-export { default, fromEntries } from 'ember-composable-helpers/helpers/from-entries';
+export { default } from 'ember-composable-helpers/helpers/from-entries';

--- a/app/helpers/pick.js
+++ b/app/helpers/pick.js
@@ -1,1 +1,1 @@
-export { default, pick } from 'ember-composable-helpers/helpers/pick';
+export { default } from 'ember-composable-helpers/helpers/pick';

--- a/app/helpers/values.js
+++ b/app/helpers/values.js
@@ -1,1 +1,1 @@
-export { default, values } from 'ember-composable-helpers/helpers/values';
+export { default } from 'ember-composable-helpers/helpers/values';

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function() {
   return {
@@ -69,16 +70,8 @@ module.exports = async function() {
           }
         }
       },
-      {
-        name: 'embroider-tests',
-        npm: {
-          devDependencies: {
-            '@embroider/core': '*',
-            '@embroider/webpack': '*',
-            '@embroider/compat': '*',
-          },
-        },
-      },
+      embroiderSafe(),
+      embroiderOptimized(),
     ]
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const { maybeEmbroider } = require('@embroider/test-setup');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
@@ -14,16 +15,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
     */
 
-  if ('@embroider/webpack' in app.dependencies()) {
-    const { Webpack } = require('@embroider/webpack'); // eslint-disable-line
-    return require('@embroider/compat') // eslint-disable-line
-      .compatBuild(app, Webpack, {
-        staticAddonTestSupportTrees: true,
-        staticAddonTrees: true,
-        staticHelpers: true,
-        staticComponents: true,
-      });
-  }
-
-  return app.toTree();
+  return maybeEmbroider(app);
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
+    "@embroider/test-setup": "^0.39.1",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,6 +1866,14 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
+"@embroider/test-setup@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.39.1.tgz#3b87c9a3a029711f43f7ac89952eaaddf30196fd"
+  integrity sha512-EYlsiPiK6FfxeB9Yq9/c/dXwTjo1T5xD6UUfK6rv0PLGP5W1OqYd0Kyf8LGpLKeaRzLD6GfOeb+GXpx9IgPyeg==
+  dependencies:
+    lodash "^4.17.20"
+    resolve "^1.17.0"
+
 "@glimmer/di@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.1.tgz#5286b6b32040232b751138f6d006130c728d4b3d"
@@ -8463,6 +8471,11 @@ lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Changes proposed in this pull request

I've been investigating Embroider in my app and have noticed that `ember-composable-helpers` generates some warnings about invalid exports. I figured it would be good to fix those!

While here, I noticed that the repo is configured to test against Embroider support with the style popularized easier in the Embroider development process. Now there's a first-party addon testing approach, which seems like the better way to ensure compatibility!