### PR TITLE
Embroider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
             ember-beta,
             ember-canary,
             ember-default-with-jquery,
-            embroider-tests,
+            embroider-safe,
+            embroider-optimized,
           ]
     continue-on-error: ${{ matrix.try-scenario == 'ember-beta' || matrix.try-scenario == 'ember-canary' }}
     steps:

--- a/addon/helpers/entries.js
+++ b/addon/helpers/entries.js
@@ -1,10 +1,10 @@
 import { helper } from '@ember/component/helper';
 
-export function keys([object]) {
+export function entries([object]) {
   if (!object) {
     return object;
   }
   return Object.entries(object);
 }
 
-export default helper(keys);
+export default helper(entries);

--- a/addon/helpers/from-entries.js
+++ b/addon/helpers/from-entries.js
@@ -1,8 +1,10 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function fromEntries([entries]) {
+export function fromEntries([entries]) {
   if (!entries) {
     return entries;
   }
   return Object.fromEntries(entries);
-});
+}
+
+export default helper(fromEntries);

--- a/addon/helpers/pick.js
+++ b/addon/helpers/pick.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 import { get } from '@ember/object';
 
-export default helper(function event([path, action]/*, hash*/) {
+export function pick([path, action]/*, hash*/) {
   return function(event) {
     let value = get(event, path);
 
@@ -11,4 +11,6 @@ export default helper(function event([path, action]/*, hash*/) {
 
     action(value);
   };
-});
+}
+
+export default helper(pick);

--- a/addon/helpers/values.js
+++ b/addon/helpers/values.js
@@ -1,8 +1,10 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function values([object]) {
+export function values([object]) {
   if (!object) {
     return object;
   }
   return Object.values(object);
-});
+}
+
+export default helper(values);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function() {
   return {
@@ -69,16 +70,8 @@ module.exports = async function() {
           }
         }
       },
-      {
-        name: 'embroider-tests',
-        npm: {
-          devDependencies: {
-            '@embroider/core': '*',
-            '@embroider/webpack': '*',
-            '@embroider/compat': '*',
-          },
-        },
-      },
+      embroiderSafe(),
+      embroiderOptimized(),
     ]
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const { maybeEmbroider } = require('@embroider/test-setup');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
@@ -14,16 +15,11 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
     */
 
-  if ('@embroider/webpack' in app.dependencies()) {
-    const { Webpack } = require('@embroider/webpack'); // eslint-disable-line
-    return require('@embroider/compat') // eslint-disable-line
-      .compatBuild(app, Webpack, {
-        staticAddonTestSupportTrees: true,
-        staticAddonTrees: true,
-        staticHelpers: true,
-        staticComponents: true,
-      });
-  }
-
-  return app.toTree();
+  return maybeEmbroider(app, {
+    skipBabel: [
+      {
+        package: 'qunit',
+      },
+    ],
+  });
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
     "@ember/test-helpers": "^2.2.5",
+    "@embroider/test-setup": "^0.39.1",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,14 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/test-setup@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.39.1.tgz#3b87c9a3a029711f43f7ac89952eaaddf30196fd"
+  integrity sha512-EYlsiPiK6FfxeB9Yq9/c/dXwTjo1T5xD6UUfK6rv0PLGP5W1OqYd0Kyf8LGpLKeaRzLD6GfOeb+GXpx9IgPyeg==
+  dependencies:
+    lodash "^4.17.20"
+    resolve "^1.17.0"
+
 "@glimmer/encoder@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.42.2.tgz#d3ba3dc9f1d4fa582d1d18b63da100fc5c664057"
@@ -8152,12 +8160,12 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.6.1:
+lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.7.0:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Changes proposed in this pull request

### Use @embroider/test-setup
Ember addons benefit on using this addon provided by embroider directly.
Read more information about it [here](https://github.com/embroider-build/embroider/tree/master/packages/test-setup).

### Fix warnings provided by embroider build:
While running `ember try:one embroider-safe` or `ember try:one embroider-optimized` you will see warnings during the build:
```  
    WARNING in /private/var/folders/1m/cqqx124s5gj0dn95jmbp91p0000mgw/T/embroider/a0a719/node_modules/ember-data/node_modules/ember-inflector/index.js 4:0-48
    "export 'defaultRules' was not found in './lib/system'
     @ ./assets/dummy.js
    
    WARNING in ./helpers/entries.js 1:0-60
    "export 'entries' was not found in '../../../helpers/entries'
     @ ./assets/dummy.js
    
    WARNING in ./helpers/from-entries.js 1:0-69
    "export 'fromEntries' was not found in '../../../helpers/from-entries'
     @ ./assets/dummy.js
    
    WARNING in ./helpers/pick.js 1:0-54
    "export 'pick' was not found in '../../../helpers/pick'
     @ ./assets/dummy.js
    
    WARNING in ./helpers/values.js 1:0-58
    "export 'values' was not found in '../../../helpers/values'
     @ ./assets/dummy.js
```
The ones related with this addon are fixed (in the [second commit](https://github.com/DockYard/ember-composable-helpers/commit/cc62c932fb72105a7c9297e08898caed43676fba)).

I had to rename `keys` to `entries` to match the expectation in `app/` re-export, but this **can be considered a breaking change**, so perhaps it will be better to change the re-export to be `keys` instead of `entries`, although that breaks the convention from the other re-exports. Open to suggestions on how you want to proceed here.