### PR TITLE
Refine GitHub workflow `CI`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,19 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint:js
 
+  floating:
+    name: Floating Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          cache: yarn
+          node-version: ${{ env.NODE_VERSION }}
+      - run: yarn install --no-lockfile --non-interactive
+      - run: yarn test
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,18 @@ jobs:
       - run: yarn test
 
   ember-try:
-    name: "Ember Try"
+    name: Ember Try
     runs-on: ubuntu-latest
     strategy:
       matrix:
         try-scenario:
-          [
-            ember-lts-3.16,
-            ember-lts-3.20,
-            ember-beta,
-            ember-canary,
-            ember-default-with-jquery,
-            embroider-safe,
-            embroider-optimized,
-          ]
+          - ember-lts-3.16
+          - ember-lts-3.20
+          - ember-beta
+          - ember-canary
+          - ember-default-with-jquery
+          - embroider-safe
+          - embroider-optimized
     continue-on-error: ${{ matrix.try-scenario == 'ember-beta' || matrix.try-scenario == 'ember-canary' }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request: {}
 
+env:
+  NODE_VERSION: 12
+
 jobs:
   lint:
     name: Lint
@@ -16,7 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: yarn
-          node-version: 12.x
+          node-version: ${{ env.NODE_VERSION }}
       - run: yarn install
       - run: yarn lint:js
 
@@ -29,7 +32,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: yarn
-          node-version: 12.x
+          node-version: ${{ env.NODE_VERSION }}
       - run: yarn install
       - run: yarn test
 
@@ -55,7 +58,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: yarn
-          node-version: 12.x
+          node-version: ${{ env.NODE_VERSION }}
       - run: yarn install
       - run: yarn ember try:one ${{ matrix.try-scenario }}
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
+          cache: yarn
           node-version: 12.x
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - run: yarn install
       - run: yarn lint:js
 
@@ -34,18 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
+          cache: yarn
           node-version: 12.x
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - run: yarn install
       - run: yarn test
 
@@ -68,18 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
+          cache: yarn
           node-version: 12.x
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - run: yarn install
       - run: yarn ember try:one ${{ matrix.try-scenario }}
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   lint:
     name: Lint
-    env:
-      CI: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,8 +30,6 @@ jobs:
 
   test:
     name: Test
-    env:
-      CI: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -55,8 +51,6 @@ jobs:
 
   ember-try:
     name: "Ember Try"
-    env:
-      CI: true
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ env:
   NODE_VERSION: 12
 
 jobs:
-  lint:
-    name: Lint
+  lint_and_tests:
+    name: Lint and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +22,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: yarn install --frozen-lockfile
       - run: yarn lint:js
+      - run: yarn test
 
   floating:
     name: Floating Dependencies
@@ -34,19 +35,6 @@ jobs:
           cache: yarn
           node-version: ${{ env.NODE_VERSION }}
       - run: yarn install --no-lockfile --non-interactive
-      - run: yarn test
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v2
-        with:
-          cache: yarn
-          node-version: ${{ env.NODE_VERSION }}
-      - run: yarn install --frozen-lockfile
       - run: yarn test
 
   ember-try:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           cache: yarn
           node-version: ${{ env.NODE_VERSION }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn lint:js
 
   test:
@@ -33,7 +33,7 @@ jobs:
         with:
           cache: yarn
           node-version: ${{ env.NODE_VERSION }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn test
 
   ember-try:
@@ -59,6 +59,6 @@ jobs:
         with:
           cache: yarn
           node-version: ${{ env.NODE_VERSION }}
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn ember try:one ${{ matrix.try-scenario }}
         timeout-minutes: 10


### PR DESCRIPTION
## Changes proposed in this pull request

I have noticed your GitHub workflow could be improved in a few ways:

- Setting manually the environment variable `CI` is redundant, GitHub already defines it.

- Simplify caching of dependencies.
  The GitHub Action `setup-node@v2` has a built-in functionality for caching and restoring dependencies.

- Make sure to install reproducible dependencies as we are in the context of a CI.

- Merge jobs `lint` and `tests` to save resources

- New job to run tests with "floating dependencies".
  I noticed this part has been previously removed, was it intended? Please let me know and I will drop this commit.

- Minor refactor to make things easier.