### PR TITLE
Allow null-like values in `queue`

### DIFF
--- a/addon/helpers/queue.js
+++ b/addon/helpers/queue.js
@@ -1,19 +1,23 @@
 import { helper } from '@ember/component/helper';
 import isPromise from '../utils/is-promise';
 
+function invokeMaybeNullable(curr, args) {
+  return curr == null ? undefined : curr(...args);
+}
+
 export function queue(actions = []) {
   return function(...args) {
     let invokeWithArgs = function(acc, curr) {
       if (isPromise(acc)) {
-        return acc.then(() => curr(...args));
+        return acc.then(() => invokeMaybeNullable(curr, args));
       }
 
-      return curr(...args);
+      return invokeMaybeNullable(curr, args);
     };
 
     return actions.reduce((acc, curr, idx) => {
       if (idx === 0) {
-        return curr(...args);
+        return invokeMaybeNullable(curr, args);
       }
 
       return invokeWithArgs(acc, curr);

--- a/tests/unit/helpers/queue-test.js
+++ b/tests/unit/helpers/queue-test.js
@@ -34,6 +34,14 @@ module('Unit | Helper | queue', function(hooks) {
     assert.ok(step3.calledOnce, 'step3 called once');
   });
 
+  test('it ignores null-like values', function(assert) {
+    let queued = queue([undefined, step1, null, step2, undefined]);
+    queued(2, 4);
+
+    assert.ok(step1.calledOnce, 'step1 called once');
+    assert.ok(step2.calledOnce, 'step2 called once');
+  });
+
   test('it passes all functions the same arguments', function(assert) {
     let queued = queue([step1, step2, step3]);
     queued(2, 4);


### PR DESCRIPTION
It's useful because one can do something like:

```hbs
{{on "click" (queue someAction (if someTest someOptionalAction))}}
```

As otherwise one must:

```hbs
{{on "click" (queue someAction (if someTest someOptionalAction (noop))}}
```

cc @snewcomer, @cibernox 