### PR TITLE
Fix `filter-by` not working when `undefined` is explicitly passed

### DIFF
--- a/addon/helpers/filter-by.js
+++ b/addon/helpers/filter-by.js
@@ -1,15 +1,17 @@
 import { helper } from '@ember/component/helper';
 import { isArray as isEmberArray } from '@ember/array';
-import { isEmpty, isPresent } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import { get } from '@ember/object';
 import isEqual from '../utils/is-equal';
 import asArray from '../utils/as-array';
 
 export function filterBy([byPath, value, array]) {
 
+  let isPresent = true;
   if (!isEmberArray(array) && isEmberArray(value)) {
     array = value;
     value = undefined;
+    isPresent = false;
   }
 
   array = asArray(array);
@@ -20,7 +22,7 @@ export function filterBy([byPath, value, array]) {
 
   let filterFn;
 
-  if (isPresent(value)) {
+  if (isPresent) {
     if (typeof value === 'function') {
       filterFn = (item) => value(get(item, byPath));
     } else {

--- a/tests/integration/helpers/filter-by-test.js
+++ b/tests/integration/helpers/filter-by-test.js
@@ -30,6 +30,24 @@ module('Integration | Helper | {{filter-by}}', function(hooks) {
     assert.dom().hasText('ac', 'b is filtered out');
   });
 
+  test('It filters by `undefined`', async function(assert) {
+    this.set('array', emberArray([
+      { foo: true, name: 'a' },
+      { foo: false, name: 'b' },
+      { foo: undefined, name: 'c' },
+      { foo: null, name: 'd' },
+      { foo: 'x', name: 'e' },
+    ]));
+
+    await render(hbs`
+      {{~#each (filter-by 'foo' undefined this.array) as |item|~}}
+        {{~item.name~}}
+      {{~/each~}}
+    `);
+
+    assert.dom().hasText('c', 'a, b, d and e are filtered out');
+  });
+
   test('It filters by truthiness', async function(assert) {
     this.set('array', emberArray([
       { foo: 'x', name: 'a' },


### PR DESCRIPTION
## Changes proposed in this pull request
The test I've added pretty much says it all. Right now `filter-by` doesn't work when explicitly checking for `undefined`.

cc @snewcomer, @cibernox
