### PR TITLE
add configFile: false to babel transform

### DIFF
--- a/lib/strip-bad-reexports.js
+++ b/lib/strip-bad-reexports.js
@@ -22,7 +22,7 @@ module.exports = class StripBadReexports extends Funnel {
       let plugins = [[stripBadReexportsTransform, { resolveBase: this.outputPath }]];
       let destFile = join(this.outputPath, file);
       unlinkSync(destFile);
-      writeFileSync(destFile, transform(src, { plugins }).code);
+      writeFileSync(destFile, transform(src, { plugins, configFile: false }).code);
     }
   }
   shouldLinkRoots() {


### PR DESCRIPTION
This fixes an issue when trying to use ember-composable-helpers with `@embroider/vite` 

Essentially when you run `babel.transform()` it will look for a babel config on disk by default. This hasn't been an issue for us in Ember for a long time since that's not how we classically built our configs, but with `@embroider/vite` we have a babel config on disk.

I'll not go too much into the details but if we don't change this behaviour there is a chicken-and-the-egg situation between embroider's pre-build of your app and addons and the true babel build for vite