### PR TITLE
⚠️ add declaration of non maintenance, and what to do about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # ⚠️ Unmaintained ⚠️ Do not use ⚠️
 
-Use this fork instead:
+With GJS / GTS / `<template>` components, most of composable-helpers is no longer needed.
+Just use JavaScript.
+For example:
+```gjs
+const getActive = (data) => data.filter(d => d.active);
+
+<template>
+  {{#each (getActive @data) as |activeData|}}
+    {{activeData.name}}
+  {{/each}}
+</template>
+```
+
+
+If you have ember-composable-helpers in your dependency graph somewhere, and/or don't want to migrate away, use this fork instead:
 https://github.com/NullVoxPopuli/ember-composable-helpers
 
 it also has instructions for dealing with dependencies that declare dependence on this copy of ember-composable-helpers.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# ⚠️ Unmaintained ⚠️ Do not use ⚠️
+
+Use this fork instead:
+https://github.com/NullVoxPopuli/ember-composable-helpers
+
+it also has instructions for dealing with dependencies that declare dependence on this copy of ember-composable-helpers.
+
+--------------------
+
 # ember-composable-helpers
 ![Download count all time](https://img.shields.io/npm/dt/ember-composable-helpers.svg) [![CircleCI](https://circleci.com/gh/DockYard/ember-composable-helpers.svg?style=shield)](https://circleci.com/gh/DockYard/ember-composable-helpers) [![npm version](https://badge.fury.io/js/ember-composable-helpers.svg)](https://badge.fury.io/js/ember-composable-helpers) [![Ember Observer Score](http://emberobserver.com/badges/ember-composable-helpers.svg)](http://emberobserver.com/addons/ember-composable-helpers)
 


### PR DESCRIPTION
This library has been forked, and improved.

The original copy, while historically influential and very useful, should not be used in new work. GJS and GTS components allow folks to just use javascript, and not need helper work-arounds.

This PR adds to the readme describing what to do.


This repo may also want to consider archival?